### PR TITLE
refactor(movableCoord): Make _convertInputType stateless

### DIFF
--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -114,7 +114,7 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 			$.extend(subOptions, options);
 
 			var inputClass = this._convertInputType(
-				subOptions.inputType, 
+				subOptions.inputType,
 				SUPPORT_TOUCH
 			);
 			if (!inputClass) {

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -113,7 +113,9 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 
 			$.extend(subOptions, options);
 
-			var inputClass = this._convertInputType(subOptions.inputType);
+			var inputClass = this._convertInputType(subOptions.inputType, {
+				isSupportTouch: SUPPORT_TOUCH
+			});
 			if (!inputClass) {
 				return this;
 			}
@@ -171,14 +173,14 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 			} catch (e) {}
 		},
 
-		_convertInputType: function(inputType) {
+		_convertInputType: function(inputType, options) {
 			var hasTouch = false;
 			var hasMouse = false;
 			inputType = inputType || [];
 			$.each(inputType, function(i, v) {
 				switch (v) {
 					case "mouse" : hasMouse = true; break;
-					case "touch" : hasTouch = SUPPORT_TOUCH;
+					case "touch" : hasTouch = options.isSupportTouch;
 				}
 			});
 

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -113,9 +113,10 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 
 			$.extend(subOptions, options);
 
-			var inputClass = this._convertInputType(subOptions.inputType, {
-				isSupportTouch: SUPPORT_TOUCH
-			});
+			var inputClass = this._convertInputType(
+				subOptions.inputType, 
+				SUPPORT_TOUCH
+			);
 			if (!inputClass) {
 				return this;
 			}
@@ -173,14 +174,14 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 			} catch (e) {}
 		},
 
-		_convertInputType: function(inputType, options) {
+		_convertInputType: function(inputType, isSupportTouch) {
 			var hasTouch = false;
 			var hasMouse = false;
 			inputType = inputType || [];
 			$.each(inputType, function(i, v) {
 				switch (v) {
 					case "mouse" : hasMouse = true; break;
-					case "touch" : hasTouch = options.isSupportTouch;
+					case "touch" : hasTouch = isSupportTouch;
 				}
 			});
 

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -1,8 +1,8 @@
 // jscs:disable maximumLineLength
-eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
+eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, global, HM) {
 	"use strict";
 
-	var SUPPORT_TOUCH = "ontouchstart" in window;
+	var SUPPORT_TOUCH = "ontouchstart" in global;
 
 	// jscs:enable maximumLineLength
 	// It is scheduled to be removed in case of build process.
@@ -174,14 +174,14 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 			} catch (e) {}
 		},
 
-		_convertInputType: function(inputType, isSupportTouch) {
+		_convertInputType: function(inputType) {
 			var hasTouch = false;
 			var hasMouse = false;
 			inputType = inputType || [];
 			$.each(inputType, function(i, v) {
 				switch (v) {
 					case "mouse" : hasMouse = true; break;
-					case "touch" : hasTouch = isSupportTouch;
+					case "touch" : hasTouch = SUPPORT_TOUCH;
 				}
 			});
 
@@ -865,4 +865,8 @@ eg.module("movableCoord", ["jQuery", eg, "Hammer"], function($, ns, HM) {
 	 * @type {Number}
 	*/
 	MC.DIRECTION_ALL = MC.DIRECTION_HORIZONTAL | MC.DIRECTION_VERTICAL;
+
+	return {
+		"MovableCoord": ns.MovableCoord
+	};
 });

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -113,10 +113,7 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 
 			$.extend(subOptions, options);
 
-			var inputClass = this._convertInputType(
-				subOptions.inputType,
-				SUPPORT_TOUCH
-			);
+			var inputClass = this._convertInputType(subOptions.inputType);
 			if (!inputClass) {
 				return this;
 			}

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -3,6 +3,7 @@
 * egjs projects are licensed under the MIT license
 */
 
+
 module("movableCoord init Test", {
 	setup : function() {
 		this.inst = null;

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -223,22 +223,58 @@ test("_convertInputType", function() {
 	// When
 	var inputType = [ "touch", "mouse" ];
 	// Then
-	equal(this.inst._convertInputType(inputType), Hammer.TouchInput, "check TouchInput");
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: true
+	}), Hammer.TouchInput, "check TouchInput");
+
+	// When
+	var inputType = [ "touch", "mouse" ];
+	// Then
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: false
+	}), Hammer.MouseInput, "check TouchInput(not supporting touch)");
+	
 	// When
 	inputType = [ "touch" ];
 	// Then
-	equal(this.inst._convertInputType(inputType), Hammer.TouchInput, "check TouchInput");
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: true
+	}), Hammer.TouchInput, "check TouchInput");
+
+	// When
+	inputType = [ "touch" ];
+	// Then
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: false
+	}), null, "check TouchInput(not supporting touch)");
+	
+	// When
+	inputType = [ "mouse" ];
+	// Then
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: true
+	}), Hammer.MouseInput, "check MouseInput");
 
 	// When
 	inputType = [ "mouse" ];
 	// Then
-	equal(this.inst._convertInputType(inputType), Hammer.MouseInput, "check MouseInput");
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: false
+	}), Hammer.MouseInput, "check MouseInput(not supporting touch)");
+	
+	// When
+	inputType = [ ];
+	// Then
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: true
+	}), null, "type is null");
 
 	// When
 	inputType = [ ];
 	// Then
-	equal(this.inst._convertInputType(inputType), null, "type is null");
-
+	equal(this.inst._convertInputType(inputType, {
+		isSupportTouch: false
+	}), null, "type is null(not supporting touch)");
 });
 
 asyncTest("setTo : check 'change' event", function() {

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -222,59 +222,46 @@ test("_convertInputType", function() {
 	// Given
 	// When
 	var inputType = [ "touch", "mouse" ];
+	var supportTouch = true;
+	var notSupportTouch = false;
+
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: true
-	}), Hammer.TouchInput, "check TouchInput");
+	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.TouchInput, "check TouchInput");
 
 	// When
 	var inputType = [ "touch", "mouse" ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: false
-	}), Hammer.MouseInput, "check TouchInput(not supporting touch)");
+	equal(this.inst._convertInputType(inputType, notSupportTouch), Hammer.MouseInput, "check TouchInput(not supporting touch)");
 	
 	// When
 	inputType = [ "touch" ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: true
-	}), Hammer.TouchInput, "check TouchInput");
+	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.TouchInput, "check TouchInput");
 
 	// When
 	inputType = [ "touch" ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: false
-	}), null, "check TouchInput(not supporting touch)");
+	equal(this.inst._convertInputType(inputType, notSupportTouch), null, "check TouchInput(not supporting touch)");
 	
 	// When
 	inputType = [ "mouse" ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: true
-	}), Hammer.MouseInput, "check MouseInput");
+	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.MouseInput, "check MouseInput");
 
 	// When
 	inputType = [ "mouse" ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: false
-	}), Hammer.MouseInput, "check MouseInput(not supporting touch)");
+	equal(this.inst._convertInputType(inputType, notSupportTouch), Hammer.MouseInput, "check MouseInput(not supporting touch)");
 	
 	// When
 	inputType = [ ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: true
-	}), null, "type is null");
+	equal(this.inst._convertInputType(inputType, supportTouch), null, "type is null");
 
 	// When
 	inputType = [ ];
 	// Then
-	equal(this.inst._convertInputType(inputType, {
-		isSupportTouch: false
-	}), null, "type is null(not supporting touch)");
+	equal(this.inst._convertInputType(inputType, notSupportTouch), null, "type is null(not supporting touch)");
 });
 
 asyncTest("setTo : check 'change' event", function() {

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -1,3 +1,8 @@
+/**
+* Copyright (c) 2015 NAVER Corp.
+* egjs projects are licensed under the MIT license
+*/
+
 module("movableCoord init Test", {
 	setup : function() {
 		this.inst = null;
@@ -215,14 +220,14 @@ test("setTo", function() {
 	this.inst.setTo(600, -900);
 	// Then
 	deepEqual(this.inst.get(), [300, 0], "if position parameters was out of range, set to position min or max values.");
-});	
-	
-asyncTest("setTo : check 'change' event", function() {
+});
+test("setTo : check 'change' event", function(assert) {
+	var done = assert.async();
 	// Given
 	this.inst.on("change", function(e) {
 		// Then
 		deepEqual(e.pos, [0, 200], "set to position 0,200");
-		start();
+		done();
 	})
 	// When
 	this.inst.setTo(0, 200, 0);
@@ -253,13 +258,14 @@ test("setBy", function() {
 	deepEqual(this.inst.get(), [300, 400], "if position parameters was out of range, set to position min or max values.");
 });
 
-asyncTest("setBy : check a 'change' event", function() {
+test("setBy : check a 'change' event", function(assert) {
+	var done = assert.async();
 	// Given
 	this.inst.setBy(20, 20);
 	this.inst.on("change", function(e) {
 		// Then
 		deepEqual(e.pos, [10, 10], "set to position -10,-10 relatively");
-		start();
+		done();
 	})
 	// When
 	this.inst.setBy(-10, -10);
@@ -302,12 +308,13 @@ test("setTo when inputType is []", function() {
 	deepEqual(this.inst.get(), [300, 0], "if position parameters was out of range, set to position min or max values.");
 });
 
-asyncTest("setTo when inputType is [] : check 'change' event", function() {
+test("setTo when inputType is [] : check 'change' event", function(assert) {
+	var done = assert.async();
 	// Given
 	this.inst.on("change", function(e) {
 		// Then
 		deepEqual(e.pos, [0, 200], "set to position 0,200");
-		start();
+		done();
 	})
 	// When
 	this.inst.setTo(0, 200, 0);
@@ -369,7 +376,6 @@ module("movableCoord setTo duration Test", {
 
 test("setTo : check event flow when maximumDuration(200ms) is bigger than a duration of setTo", function(assert) {
 	var done = assert.async();
-
 	// Given
 	var self = this;
 	// When
@@ -432,7 +438,8 @@ module("movableCoord event Test", {
 	}
 });
 
-asyncTest("slow movement test (no-velocity)", function() {
+test("slow movement test (no-velocity)", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var firedHold =0;
@@ -482,12 +489,13 @@ asyncTest("slow movement test (no-velocity)", function() {
 			equal(firedHold, 1, "fired 'hold' event");
 			equal(firedRelease, 1,"fired 'release' event");
 			equal(firedAnimationEnd, 1, "fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
 
-asyncTest("slow movement test (no-velocity), release outside", function() {
+test("slow movement test (no-velocity), release outside", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var firedHold =0;
@@ -543,12 +551,13 @@ asyncTest("slow movement test (no-velocity), release outside", function() {
 			equal(firedRelease, 1,"fired 'release' event");
 			equal(firedAnimationStart, 1, "fired 'animationStrt' event");
 			equal(firedAnimationEnd, 1, "fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
 
-asyncTest("fast movement test (velocity)", function() {
+test("fast movement test (velocity)", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var firedHold = 0;
@@ -606,12 +615,13 @@ asyncTest("fast movement test (velocity)", function() {
 			equal(firedRelease,1,"fired 'release' event");
 			equal(firedAnimationStart, 1,"fired 'animationStart' event");
 			equal(firedAnimationEnd, 1,"fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
 
-asyncTest("movement test when stop method was called in 'animationStart' event", function() {
+test("movement test when stop method was called in 'animationStart' event", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var timer = null;
@@ -665,7 +675,7 @@ asyncTest("movement test when stop method was called in 'animationStart' event",
 			equal(firedRelease,1,"fired 'release' event");
 			equal(firedAnimationStart, 1,"fired 'animationStart' event");
 			equal(firedAnimationEnd, 1,"fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
@@ -688,7 +698,8 @@ module("movableCoord interrupt Test", {
 });
 
 
-asyncTest("interrupt test when user's action is fast", function() {
+test("interrupt test when user's action is fast", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var firedHold = 0;
@@ -748,12 +759,13 @@ asyncTest("interrupt test when user's action is fast", function() {
 			equal(firedRelease,1,"fired 'release' event");
 			equal(firedAnimationStart, 1,"fired 'animationStart' event");
 			equal(firedAnimationEnd, 1,"fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
 
-asyncTest("interrupt test when stop method was called in 'animationStart' event", function() {
+test("interrupt test when stop method was called in 'animationStart' event", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var timer = null;
@@ -809,7 +821,7 @@ asyncTest("interrupt test when stop method was called in 'animationStart' event"
 			equal(firedRelease,1,"fired 'release' event");
 			equal(firedAnimationStart, 1,"fired 'animationStart' event");
 			equal(firedAnimationEnd, 1,"fired 'animationEnd' event");
-			start();
+			done();
 		},1000);
     	});
 });
@@ -841,7 +853,8 @@ test("interrupt test when 'setTo' method is called : duration = 0", function() {
 });
 
 
-asyncTest("interrupt test when 'setTo' method is called : duration = 100", function() {
+test("interrupt test when 'setTo' method is called : duration = 100", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	equal(this.inst._status.prevented, false, "init value is 'false'");
@@ -870,12 +883,13 @@ asyncTest("interrupt test when 'setTo' method is called : duration = 100", funct
 		setTimeout(function() {
 			// Then
 			equal(self.inst._status.prevented, false, "prevented property is 'false'");
-			start();
+			done();
 		},150);
 	},150);
 });
 
-asyncTest("interrupt test after 'setTo' method is called : move to same position", function() {
+test("interrupt test after 'setTo' method is called : move to same position", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	equal(this.inst._status.prevented, false, "init value is 'false'");
@@ -905,13 +919,14 @@ asyncTest("interrupt test after 'setTo' method is called : move to same position
 		setTimeout(function() {
 			// Then
 			equal(self.inst._status.prevented, false, "prevented property is 'false'");
-			start();
+			done();
 		},150);
 	},150);
 });
 
 
-asyncTest("interrupt test after tap gesture", function() {
+test("interrupt test after tap gesture", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 	var firedHold =0;
@@ -952,7 +967,7 @@ asyncTest("interrupt test after tap gesture", function() {
 		setTimeout(function() {
 			equal(firedHold,1,"fired 'hold' event");
 			equal(firedRelease,1,"fired 'release' event");
-			start();
+			done();
 		},1000);
     	});
 });
@@ -1003,7 +1018,8 @@ test("check user's direction", function() {
 });
 
 
-asyncTest("movement direction test (DIRECTION_ALL)", function() {
+test("movement direction test (DIRECTION_ALL)", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 
@@ -1027,12 +1043,13 @@ asyncTest("movement direction test (DIRECTION_ALL)", function() {
             duration: 2000,
             easing: "linear"
 	}, function() {
-		start();
+		done();
     	});
 });
 
 
-asyncTest("movement direction test (DIRECTION_HORIZONTAL)", function() {
+test("movement direction test (DIRECTION_HORIZONTAL)", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 
@@ -1056,12 +1073,13 @@ asyncTest("movement direction test (DIRECTION_HORIZONTAL)", function() {
             duration: 2000,
             easing: "linear"
 	}, function() {
-		start();
+		done();
     	});
 });
 
 
-asyncTest("movement direction test (DIRECTION_VERTICAL)", function() {
+test("movement direction test (DIRECTION_VERTICAL)", function(assert) {
+	var done = assert.async();
 	//Given
 	var el = $("#area").get(0);
 
@@ -1085,7 +1103,7 @@ asyncTest("movement direction test (DIRECTION_VERTICAL)", function() {
             duration: 2000,
             easing: "linear"
 	}, function() {
-		start();
+		done();
     	});
 });
 

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -215,55 +215,8 @@ test("setTo", function() {
 	this.inst.setTo(600, -900);
 	// Then
 	deepEqual(this.inst.get(), [300, 0], "if position parameters was out of range, set to position min or max values.");
-});
-
-
-test("_convertInputType", function() {
-	// Given
-	// When
-	var inputType = [ "touch", "mouse" ];
-	var supportTouch = true;
-	var notSupportTouch = false;
-
-	// Then
-	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.TouchInput, "check TouchInput");
-
-	// When
-	var inputType = [ "touch", "mouse" ];
-	// Then
-	equal(this.inst._convertInputType(inputType, notSupportTouch), Hammer.MouseInput, "check TouchInput(not supporting touch)");
+});	
 	
-	// When
-	inputType = [ "touch" ];
-	// Then
-	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.TouchInput, "check TouchInput");
-
-	// When
-	inputType = [ "touch" ];
-	// Then
-	equal(this.inst._convertInputType(inputType, notSupportTouch), null, "check TouchInput(not supporting touch)");
-	
-	// When
-	inputType = [ "mouse" ];
-	// Then
-	equal(this.inst._convertInputType(inputType, supportTouch), Hammer.MouseInput, "check MouseInput");
-
-	// When
-	inputType = [ "mouse" ];
-	// Then
-	equal(this.inst._convertInputType(inputType, notSupportTouch), Hammer.MouseInput, "check MouseInput(not supporting touch)");
-	
-	// When
-	inputType = [ ];
-	// Then
-	equal(this.inst._convertInputType(inputType, supportTouch), null, "type is null");
-
-	// When
-	inputType = [ ];
-	// Then
-	equal(this.inst._convertInputType(inputType, notSupportTouch), null, "type is null(not supporting touch)");
-});
-
 asyncTest("setTo : check 'change' event", function() {
 	// Given
 	this.inst.on("change", function(e) {
@@ -413,6 +366,7 @@ module("movableCoord setTo duration Test", {
 		this.inst = null;
 	}
 });
+
 asyncTest("setTo : check event flow when maximumDuration(200ms) is bigger than a duration of setTo", function() {
 	// Given
 	var self = this;
@@ -1129,4 +1083,76 @@ asyncTest("movement direction test (DIRECTION_VERTICAL)", function() {
 	}, function() {
 		start();
     	});
+});
+
+test("_convertInputType (support touch)", function() {
+	// Given
+	var globalWithToucnSupport = {
+		"ontouchstart": {}
+	};
+	var method = eg.invoke("movableCoord", [jQuery, eg, globalWithToucnSupport, Hammer]);
+	var inst = new method.MovableCoord( {
+		min : [ 0, 0 ],
+		max : [ 300, 400 ],
+		bounce : 100,
+		margin : 0,
+		circular : false
+	});
+	var supportTouch = true;
+	var notSupportTouch = false;
+	
+	// When		
+	var inputType = [ "touch", "mouse" ];
+	// Then
+	equal(inst._convertInputType(inputType), Hammer.TouchInput, "check TouchInput");
+	
+	// When
+	inputType = [ "touch" ];
+	// Then
+	equal(inst._convertInputType(inputType), Hammer.TouchInput, "check TouchInput");
+	
+	// When
+	inputType = [ "mouse" ];
+	// Then
+	equal(inst._convertInputType(inputType), Hammer.MouseInput, "check MouseInput");
+	
+	// When
+	inputType = [ ];
+	// Then
+	equal(inst._convertInputType(inputType), null, "type is null");
+});
+
+test("_convertInputType (not support touch)", function() {
+	// Given
+	var globalWithoutToucnSupport = {};
+	var method = eg.invoke("movableCoord", [jQuery, eg, globalWithoutToucnSupport, Hammer]);
+	var inst = new method.MovableCoord( {
+		min : [ 0, 0 ],
+		max : [ 300, 400 ],
+		bounce : 100,
+		margin : 0,
+		circular : false
+	});
+	var supportTouch = true;
+	var notSupportTouch = false;
+	
+	// When
+	var inputType = [ "touch", "mouse" ];
+	// Then
+	equal(inst._convertInputType(inputType), Hammer.MouseInput, "check TouchInput(not supporting touch)");
+	
+	// When
+	inputType = [ "touch" ];
+	// Then
+	equal(inst._convertInputType(inputType), null, "check TouchInput(not supporting touch)");
+	
+	// When
+	inputType = [ "mouse" ];
+	// Then
+	equal(inst._convertInputType(inputType), Hammer.MouseInput, "check MouseInput(not supporting touch)");
+	
+	// When
+	inputType = [ ];
+	// Then
+	equal(inst._convertInputType(inputType), null, "type is null(not supporting touch)");
 });

--- a/test/js/movableCoord.test.js
+++ b/test/js/movableCoord.test.js
@@ -367,7 +367,9 @@ module("movableCoord setTo duration Test", {
 	}
 });
 
-asyncTest("setTo : check event flow when maximumDuration(200ms) is bigger than a duration of setTo", function() {
+test("setTo : check event flow when maximumDuration(200ms) is bigger than a duration of setTo", function(assert) {
+	var done = assert.async();
+
 	// Given
 	var self = this;
 	// When
@@ -378,11 +380,12 @@ asyncTest("setTo : check event flow when maximumDuration(200ms) is bigger than a
 		ok(self.firedChangeEvent, "fired 'change' event");
 		equal(self.firedAnimationStartEvent, 1, "fired 'animationStart' event");
 		equal(self.firedAnimationEndEvent, 1, "fired 'animationEnd' event");
-		start();
+		done();
 	},150);
 });
 
-asyncTest("setTo : check event flow when a duration of setTo is bigger than maximumDuration(200ms)", function() {
+test("setTo : check event flow when a duration of setTo is bigger than maximumDuration(200ms)", function(assert) {
+	var done = assert.async();
 	// Given
 	var self = this;
 
@@ -394,11 +397,12 @@ asyncTest("setTo : check event flow when a duration of setTo is bigger than maxi
 		ok(self.firedChangeEvent, "fired 'change' event");
 		equal(self.firedAnimationStartEvent, 1, "fired 'animationStart' event");
 		equal(self.firedAnimationEndEvent, 1, "fired 'animationEnd' event");
-		start();
+		done();
 	},250);
 });
 
-asyncTest("setTo : check event flow when a duration of setTo is '0'", function() {
+test("setTo : check event flow when a duration of setTo is '0'", function(assert) {
+	var done = assert.async();
 	// Given
 	var self = this;
 
@@ -409,7 +413,7 @@ asyncTest("setTo : check event flow when a duration of setTo is '0'", function()
 	ok(self.firedChangeEvent, "fired 'change' event");
 	equal(self.firedAnimationStartEvent, 0, "not fired 'animationStart' event");
 	equal(self.firedAnimationEndEvent, 0, "not fired 'animationEnd' event");
-	start();
+	done();
 });
 
 module("movableCoord event Test", {


### PR DESCRIPTION
## Issue
#42 

## Details
Make _convertInputType method stateless and Update tests

## Preferred reviewers
@sculove @kishu 