### PR TITLE
fix(module): Fix potential error with Require. Can define 'require' o…

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -73,7 +73,7 @@
 			isUndefined = di[i] === undefined;
 			registedDependency = isString && (dependencyInfo = dependency[di[i]]);
 			isNotGlobal = isString && dependencyInfo && !global[di[i]];
-			specifiedAMD = isNotGlobal && require && require.specified(di[i]);
+			specifiedAMD = isNotGlobal && require && require.specified && require.specified(di[i]);
 
 			// Message decision flow
 			//             argument

--- a/src/module.js
+++ b/src/module.js
@@ -73,7 +73,8 @@
 			isUndefined = di[i] === undefined;
 			registedDependency = isString && (dependencyInfo = dependency[di[i]]);
 			isNotGlobal = isString && dependencyInfo && !global[di[i]];
-			specifiedAMD = isNotGlobal && require && require.specified && require.specified(di[i]);
+			specifiedAMD = isNotGlobal &&
+				require && require.specified && require.specified(di[i]);
 
 			// Message decision flow
 			//             argument


### PR DESCRIPTION
# Details
Fix a potential error with RequireJS. People can define the object as the global variable "require" before require.js is loaded. And there can be bad time "require" object is not Require function object and do not include "specified" function.

# Reference
http://requirejs.org/docs/api.html#config

# Ex
```html
<script type="text/javascript">
var require = { baseUrl: '/js' };
</script>
<script src="/bower_components/jquery/dist/jquery.js"></script>
<script src="/bower_components/hammer.js/hammer.js"></script>
<script src="/bower_components/egjs/dist/eg.js"></script>
<script src="/bower_components/requirejs/require.js"></script>
```