### PR TITLE
test(module): Add testcase when has not require.specified method.

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -122,7 +122,8 @@
 				continue;
 			}
 
-			if (isNotGlobal && require && !require.specified(di[i])) {
+			if (isNotGlobal && require &&
+				require.specified && !require.specified(di[i])) {
 				messageInfo.url = dependencyInfo.url;
 				message.push(replaceStr(templateMessage[1], messageInfo));
 				continue;

--- a/test/unit/js/module.test.js
+++ b/test/unit/js/module.test.js
@@ -128,6 +128,22 @@ QUnit.test( "When a parameter is string and not loaded as AMD.", function( asser
   });
 });
 
+QUnit.test( "When a parameter is string and has require but has not .specified", function( assert ) {
+  //Given
+  window.require = { baseUrl: '/js' };
+  //When
+  //Then
+  try{
+    eg.module("Only has require",["jQuery"],function($) {
+      assert.ok(true);
+    });  
+  }catch(e){
+    assert.ok(false);
+  }
+  
+});
+
+
 QUnit.test( "When a parameter is string and not loaded as AMD.", function( assert ) {
   //Given
   var Hammer = {};


### PR DESCRIPTION
# Detail
Add testcase for #75.
I think that  #75 is unnecessary pr. When is below case that `egjs` not working. So. `egjs` have to position above `require`.

```js
<script type="text/javascript">
var require = { baseUrl: '/js' };
</script>
<script src="/bower_components/jquery/dist/jquery.js"></script>
<script src="/bower_components/hammer.js/hammer.js"></script>
<script src="/bower_components/egjs/dist/eg.js"></script>
<script src="/bower_components/requirejs/require.js"></script>
```

# Related Issue
#75, #112

# Preferred Reviewer
@netil , @happyhj 