### PR TITLE
fix(persist): block throwing exception when storage is polluted

### DIFF
--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -22,6 +22,7 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 	var isBackForwardNavigated = (wp && wp.navigation &&
 									(wp.navigation.type === (wp.navigation.TYPE_BACK_FORWARD || 2)));
 	var isSupportState = "replaceState" in history && "state" in history;
+
 	var storage = (function() {
 		if (!isSupportState) {
 			if ("sessionStorage" in global) {
@@ -71,33 +72,42 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 	function getState() {
 		var stateStr;
 		var state = {};
+		var isValidStateStr = false;
+
 		if (isSupportState) {
 			stateStr = history.state;
 
-			// "string", "null" is not a valid
+			// "null" is not a valid
 			if (typeof stateStr === "string" && stateStr !== "null") {
-				try {
-					state = JSON.parse(stateStr);
-
-					// like '[ ... ]', '1', '1.234', '"123"' is also not valid
-					if (jQuery.type(state) !== "object" || state instanceof Array) {
-						throw new Error("window.history has no valid format data " +
-							"to be handled in persist.");
-					}
-				} catch (e) {
-					/* jshint ignore:start */
-					console.warn(e.message);
-					/* jshint ignore:end */
-				}
+				isValidStateStr = true;
 			}
-			return state;
 		} else {
 			stateStr = storage.getItem(location.href + CONST_PERSIST);
-
-			// Note2 (Android 4.3) return value is null
-			return (stateStr && stateStr.length > 0) ? JSON.parse(stateStr) : {};
+			if (stateStr && stateStr.length > 0) {
+				isValidStateStr = true;
+			}
 		}
+
+		if (isValidStateStr) {
+			try {
+				state = JSON.parse(stateStr);
+
+				// like '[ ... ]', '1', '1.234', '"123"' is also not valid
+				if (jQuery.type(state) !== "object" || state instanceof Array) {
+					throw new Error();
+				}
+			} catch (e) {
+				/* jshint ignore:start */
+				console.warn("window.history or session/localStorage has no valid " +
+						"format data to be handled in persist.");
+				/* jshint ignore:end */
+			}
+		}
+
+		// Note2 (Android 4.3) return value is null
+		return state;
 	}
+
 	function getStateByKey(key) {
 		var result = getState()[key];
 
@@ -114,7 +124,11 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 	function setState(state) {
 		if (isSupportState) {
 			try {
-				history.replaceState(JSON.stringify(state), doc.title, location.href);
+				history.replaceState(
+					state === null ? null : JSON.stringify(state),
+					doc.title,
+					location.href
+				);
 			} catch (e) {
 				/* jshint ignore:start */
 				console.warn(e.message);

--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -78,14 +78,10 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 			stateStr = history.state;
 
 			// "null" is not a valid
-			if (typeof stateStr === "string" && stateStr !== "null") {
-				isValidStateStr = true;
-			}
+			isValidStateStr = typeof stateStr === "string" && stateStr !== "null";
 		} else {
 			stateStr = storage.getItem(location.href + CONST_PERSIST);
-			if (stateStr && stateStr.length > 0) {
-				isValidStateStr = true;
-			}
+			isValidStateStr = stateStr && stateStr.length > 0;
 		}
 
 		if (isValidStateStr) {

--- a/test/unit/js/persist.test.js
+++ b/test/unit/js/persist.test.js
@@ -4,8 +4,13 @@
 */
 
 function noop() {};
-module("persist", {
+
+module("persist: mock", {
 	setup: function() {
+		this.data = {
+			"scrollTop": 100
+		};
+
 		this.fakeDocument = {
 			title: ""
 		};
@@ -38,13 +43,8 @@ module("persist", {
 			}
 		};
 		this.fakeEvent = {};
-		this.data = {
-			"scrollTop": 100
-		};
 		this.storage = {};
-
-		this.method = eg.invoke("persist",[null, eg, this.fakeWindow, this.fakeDocument]);
-		this.GLOBALKEY = this.method.GLOBALKEY;
+		
 		/*
 		 *	 Mock History Object
 		*/
@@ -54,7 +54,10 @@ module("persist", {
 
 		History.prototype.replaceState = function(state) {
 			this.state = state;
-		};
+		};	
+		
+		this.method = eg.invoke("persist",[null, eg, this.fakeWindow, this.fakeDocument]);
+		this.GLOBALKEY = this.method.GLOBALKEY;
 	},
 	teardown: function() {
 		"replaceState" in this.fakeWindow.history && this.fakeWindow.history.replaceState(null, "", "");
@@ -72,7 +75,7 @@ test("reset", function() {
 test("persist : save state data, get state data", function() {
 	// When
 	var state = this.method.persist();
-
+	
 	// Then
 	equal(state, null);
 
@@ -103,11 +106,10 @@ test("onPageshow : when bfCache miss and not BF navigated, _reset method must be
 	var ht = {};
 	ht[this.GLOBALKEY] = this.data;
 	this.fakeWindow.performance.navigation.type = 2;	// navigation
-	this.fakeWindow.history.state = JSON.stringify(ht);
-
 	var method = eg.invoke("persist",[null, eg, this.fakeWindow, this.fakeDocument]);
+	method.persist(this.data)
 	deepEqual(method.persist(), this.data);
-
+	
 	// When
 	$(this.fakeWindow).trigger({
 		type: "pageshow",
@@ -118,7 +120,6 @@ test("onPageshow : when bfCache miss and not BF navigated, _reset method must be
 
 	// Then
 	deepEqual(method.persist(), this.data);
-
 
 	// When
 	this.fakeWindow.performance.navigation.type = 0;	// enter url...
@@ -139,7 +140,6 @@ test("onPageshow : when bfCache miss and not BF navigated, _reset method must be
 	// Then
 	equal(method.persist(), null);
 
-
 	// When
 	this.fakeWindow.performance.navigation.type = 1;
 	this.fakeWindow.history.state = JSON.stringify(ht);
@@ -158,6 +158,7 @@ test("onPageshow : when bfCache miss and not BF navigated, _reset method must be
 
 	// Then
 	equal(method.persist(), null);
+
 });
 
 test("getState, setState: getter, setter of state", function() {
@@ -198,8 +199,8 @@ test("onPageshow : when bfCache miss and BF navigated, persist event must be tri
 
 	// Then
 	deepEqual(restoredState, clonedData);
- });
-
+});
+ 
 test("Test not throwing error for legacy browsers", function() {
 	// Given
 	this.fakeWindow.history = {};
@@ -227,6 +228,131 @@ test("Test for browsers which don't have JSON object", function() {
 	// Then
 	ok(!method, "If browser don't have JSON object, persist shouldn't be defined.");
 	equal(callCount, 1);
+
+	console.warn = console.oldWarn;
+});
+
+module("persist: native", {
+	setup: function() {
+		this.data = {
+			"scrollTop": 100
+		};
+		this.method = eg.invoke("persist",[null, eg, window, document]);
+		this.GLOBALKEY = this.method.GLOBALKEY;
+	},
+	teardown: function() {
+		"replaceState" in window.history && window.history.replaceState(null, "", "");
+	}
+});
+
+test("reset", function() {
+	// When
+	this.method.reset();
+
+	// Then
+	equal($.persist(), null);
+});
+
+test("persist : save state data, get state data", function() {
+	// When
+	var state = this.method.persist();
+	
+	// Then
+	equal(state, null);
+
+	// When
+	var clonedState = this.method.persist(this.data);
+	
+	// Then
+	notEqual(clonedState, this.data);
+	deepEqual(clonedState, this.data);
+});
+
+test("persist : save state data by key, get state data by key", function() {
+	// When
+	var state = this.method.persist("TESTKEY");
+
+	// Then
+	equal(state, null);
+
+	// When
+	var clonedState = this.method.persist("TESTKEY", this.data);
+
+	// Then
+	notEqual(clonedState, this.data);
+	deepEqual(clonedState, this.data);
+});
+
+$.each(['{', '[ 1,2,3 ]', '1', '1.234', '"123"'], function(i, v) {
+	test("show warning message for storage polloution with value that can be parsed: "+ v, function() {	
+		// Given		
+		console.oldWarn = console.warn;
+		var callCount = 0;
+		console.warn = function(msg){
+			callCount++;
+		};
+		var clonedState = this.method.persist(this.data);
+		var isSupportState = "replaceState" in history && "state" in history;	
+		var isNoExceptionThrown = true;
+		if(isSupportState) {
+			history.replaceState(v, document.title, location.href);
+		} else {
+			sessionStorage.setItem(location.href + "___persist___", v);
+			localStorage.setItem(location.href + "___persist___", v);		
+		}
+	
+		// When	
+		try {
+			this.method.persist();
+		} catch (e) {
+			isNoExceptionThrown = false;
+		}
+	
+		// Then	
+		equal(callCount, 1);
+		ok(isNoExceptionThrown)
+	
+		console.warn = console.oldWarn;
+	});
+});
+
+test("getState, setState: getter, setter of state", function() {
+	// When
+	this.method.setState(this.data);
+	var clonedData = this.method.getState();
+
+	// Then
+	deepEqual(clonedData, this.data);
+});
+
+test("Test not throwing error for legacy browsers", function() {
+	// Given
+	var isPersistAvailable = ("replaceState" in history && "state" in history) ||
+	"sessionStorage" in window || "localStorage" in window;	
+
+	// When
+	var persist = eg.invoke("persist",[null, eg, window, document]);
+	
+	// Then
+	ok(isPersistAvailable ? persist : !persist, 
+		"If browser don't have history.state neither web storage, persist shouldn't be defined.");
+});
+
+test("Test for browsers which don't have JSON object", function() {
+	// Given
+	var isSupportJSON = "JSON" in window;
+	console.oldWarn = console.warn;
+	var callCount=0;
+	console.warn = function(msg){
+		callCount++;
+	}
+
+	// When
+	var persist = eg.invoke("persist",[null, eg, window, document]);
+
+	// Then
+	ok(isSupportJSON ? persist : !persist, "If browser don't have JSON object, persist shouldn't be defined.");
+	equal(callCount, isSupportJSON ? 0 : 1);
 
 	console.warn = console.oldWarn;
 });
@@ -287,7 +413,7 @@ module("extend Agent Test", {
 	}
 });
 
-ua.forEach(function(v,i) {
+$.each(ua, function(i, v) {
 	test("$.persist.isNeeded : "+ v.device, function() {
 		// Given
 		this.fakeWindow.navigator.userAgent = v.ua;


### PR DESCRIPTION
## Desc
### tests
* Add suit of unit tests to test native host, not mocked environment.
* Add unit test for check that persist prevents throwing exception when storage is polluted.
* Change Array.forEach to jQuery.each at persist.test.js for IE8

### getState method
* Changed to show warning message and not throwing exceptions when storage is polluted and value  comes invalid for persist.
* Use try catch block with session/localStorage when call getState.

### setState method
* If state is null object, make it not call JSON.stringify before store the value.

## Issue
ref #14

## Preferred reviewer
@netil , @kishu
