### PR TITLE
Bs#139: improve browserstack test runner process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ temp
 doc
 .idea/
 dist
+browserstack-run.pid
+config/browertstack.config.json

--- a/config/browserstack.js
+++ b/config/browserstack.js
@@ -8,7 +8,6 @@ module.exports = function(grunt){
 	// if there is no @support tag in src, use defaultSupport (ex. eg.js)
 	var DEFAULT_SUPPORT = {"ie": "7+", "ch" : "latest", "ff" : "latest",  "sf" : "latest", "ios" : "7+", "an" : "2.1+ (except 3.x)"};
 	var VM_COUNT = 2;
-	var VM_COUNT = 2;
 
 	var moduleList = fetchModuleList();
 	

--- a/config/browserstack.js
+++ b/config/browserstack.js
@@ -15,8 +15,8 @@ module.exports = function(grunt){
 	}).map(function(val){
 		return val.split('.')[0];
 	});
-
-	// fetch module src path
+		
+	// fetch module src path 	
 	var srcPathList = walk("src");
 	moduleList = moduleList.map(function(val){
 		for(var i in srcPathList) {
@@ -28,8 +28,8 @@ module.exports = function(grunt){
 			}
 		}
 	});
-
-	// fetch module support info from jsdoc
+		
+	// fetch module support info from jsdoc	
 	moduleList = moduleList.map(function(val){
 		var data = fs.readFileSync(val.path, 'utf8');
 		var supportLine = data.split('\n').filter(function(val){
@@ -43,7 +43,7 @@ module.exports = function(grunt){
 	function walk(dir) {
 	    var results = []
 	    var list = fs.readdirSync(dir);
-
+	    
 	    list.forEach(function(file) {
 	        file = dir + '/' + file
 	        var stat = fs.statSync(file)
@@ -51,6 +51,47 @@ module.exports = function(grunt){
 	        else results.push(file)
 	    })
 	    return results
+	}
+	
+	function isSameBrowser(browser1, browser2) {
+		if(JSON.stringify(browser1) === JSON.stringify(browser2)) {
+			return true;
+		}
+		return false;
+	}
+	
+	function hasBrowser(browserList, browser) {
+		return browserList.some(function(val){
+			return isSameBrowser(val, browser);
+		});
+	}
+	
+	function getConfigByBrowser() {
+		// moduleList getConfig
+		var configList = moduleList.map(function(val) {
+			return getConfig(val.name);
+		});
+		
+		var browsers = [];
+		for(var i in bsLaunchers) {
+			browsers = browsers.concat(bsLaunchers[i]);
+		}
+		var configListByBrowser = browsers.map(function(val){
+			return { 
+				test_framework: 'qunit',
+				test_path: [],
+				browsers: [val]
+			}
+		});
+		
+		configListByBrowser.forEach(function(config) {
+			configList.forEach(function(val) {
+				if(hasBrowser(val.browsers, config.browsers[0])) {
+					config.test_path.push(val.test_path[0]);
+				}
+			});
+		});	
+		return configListByBrowser;
 	}
 
 	// returns target browserstack launchers
@@ -61,7 +102,7 @@ module.exports = function(grunt){
 		}).map(function(val){
 			return val.support;
 		})[0];
-
+	
 		for(var browser in componentSupport) {
 			if(/^(ie|ios|an|ch|ff)$/.test(browser) && componentSupport[browser] !== "latest") {
 				var lowestVersion = parseFloat(componentSupport[browser]);
@@ -77,57 +118,90 @@ module.exports = function(grunt){
 				);
 			}
 		}
-		return {
+		return {	
 			"test_framework": "qunit",
 			"test_path": [
 			"test/unit/"+componentName+".test.html"
 			],
 			"browsers": targetBrowsers
 		};
-	}
+	}	
 
+	grunt.registerTask('browserstack_runner', function() {
+		var isByBrowser = arguments[0] === "byBrowser" ? true : false;
+		var browserstackConfig;
+		if(!isByBrowser) {
+			browserstackConfig = getConfig(arguments[0]);
+			var bIdx = 2 * (parseInt(arguments[1]) + 1) - 2;
+			var totalBrowser = browserstackConfig.browsers.length;
+			var browsers = browserstackConfig.browsers;
+			var targetBrowsers = [];
+			targetBrowsers.push(browsers[bIdx]);
+			browsers[bIdx + 1] && targetBrowsers.push(browsers[bIdx + 1]);			
+			browserstackConfig.browsers = targetBrowsers;
+			if(browserstackConfig.browsers.length === 1) {
+				grunt.log.writeln("["+bIdx +"/" + totalBrowser + "]");
+			} else {
+				grunt.log.writeln("["+bIdx + ","+(bIdx+1)+"/" + totalBrowser + "]");
+			}
+			runBrowserstackRunner.call(this, browserstackConfig);	
+		} else {
+			var configListByBrowser = getConfigByBrowser();
+			browserstackConfig = configListByBrowser[arguments[1]];
+			runBrowserstackRunner.call(this, browserstackConfig);	
+		}
+	});
+
+	function runBrowserstackRunner(browserstackConfig) {
+		var tempBrowserstackConfig = "config/browertstack.config.json";
+		process.env["BROWSERSTACK_JSON"] = tempBrowserstackConfig;
+		fs.writeFileSync(tempBrowserstackConfig, JSON.stringify(browserstackConfig), "utf8");
+	
+		var done = this.async();
+		
+		var subProcess = exec("node_modules/.bin/browserstack-runner --verbose", function(err) {
+			var fs = require("fs");
+			done(err ? false : true);
+		});
+		
+		subProcess.stdout.on("data", function(_data) {
+			grunt.log.writeln(_data.trim());
+		});		
+	}
+	
 	/*
-	**	grunt browserstack:muduleName
+	**	$ grunt browserstack:muduleName
 	**	    run unit tests with browserstack for muduleName
-	**  grunt browserstack
+	**  $ grunt browserstack
 	**	    run unit tests with browserstack for every module
-	*/
+	*/	 
 	grunt.registerTask('browserstack', isBrowserStack ? function() {
 		var eachfile = Array.prototype.slice.apply(arguments);
 		var taskList;
-		if (eachfile.length) {
+		if (eachfile.length >= 1) {
 			taskList = eachfile.map(function(v) {
 				return v;
-			}, this);
+			}, this);			
+
+			taskList = taskList.map(function(val){
+				var browserCount = getConfig(val).browsers.length;
+				var	b = Array.apply(null, Array(browserCount)).map(function(x,i){
+					return 'browserstack_runner:' + val + ':' +i;
+				});
+				b = b.slice(0, Math.floor(b.length/2.0));
+				return b;
+			}).reduce(function(prev, cur) {
+				var prev = prev || [];
+				return 	prev.concat(cur);
+			});
 		} else {
-			// fetch module name list from html files in test directory
-			taskList = fs.readdirSync("test/unit/").filter(function(val) {
-				return val.split(".").length === 3 && val.split(".")[0] !== "buildMerge";
-			}).map(function(val) {
-				return val.split(".")[0];
+			var browserCount = getConfigByBrowser().length;
+			var	taskList = Array.apply(null, Array(browserCount)).map(function(x,i){
+				return 'browserstack_runner:byBrowser:' + i;
 			});
-		}
-
-		taskList.forEach(function(targetModuleName){
-			startSingleBrowserstackSession.call(this, targetModuleName);
-		}.bind(this));
-
-		function startSingleBrowserstackSession(targetModuleName) {
-			var browserstackConfig = getConfig(targetModuleName);
-			var tempBrowserstackConfig = "config/browertstack.config.json";
-			fs.writeFileSync(tempBrowserstackConfig, JSON.stringify(browserstackConfig), "utf8");
-			process.env["BROWSERSTACK_JSON"] = tempBrowserstackConfig;
-			var done = this.async();
-			var subProcess = exec("node_modules/.bin/browserstack-runner", function(err) {
-				var fs = require("fs");
-				process.env["BROWSERSTACK_JSON"] = "";
-				fs.unlinkSync(tempBrowserstackConfig);
-				done(err ? false : true);
-			});
-			subProcess.stdout.on("data", function(_data) {
-				grunt.log.writeln(_data.trim());
-			});
-		}
+			taskList = taskList.slice(0, Math.floor(taskList.length/2.0));			
+		}		
+		grunt.task.run(taskList);
 	} : function() {
 		grunt.log.oklns("no BROWSERSTACK_USERNAME, BROWSERSTACK_KEY env");
 	});

--- a/config/browserstack_launchers.js
+++ b/config/browserstack_launchers.js
@@ -27,34 +27,36 @@ module.exports = {
 		"os": "Windows",
 		"os_version": "10"
 	}],
-	"ch": [{
+	"ch": [/*
+{
 		"browser": "chrome",
 		"browser_version": "45.0",
 		"os": "OS X",
 		"os_version": "Yosemite"
-	},{
+	}
+,{
 		"browser": "chrome",
 		"browser_version": "46.0",
 		"os": "OS X",
 		"os_version": "Yosemite"
-	},{
+	},*/{
 		"browser": "chrome",
 		"browser_version": "47.0",
 		"os": "OS X",
 		"os_version": "Yosemite"
 	}],
-	"ff": [{
+	"ff": [/*{
 		"browser": "firefox",
 		"browser_version": "41.0",
 		"os": "OS X",
 		"os_version": "Yosemite"
-	},{
+	},*/{
 		"browser": "firefox",
 		"browser_version": "42.0",
 		"os": "OS X",
 		"os_version": "Yosemite"
 	}],
-	"sf": [{
+	"sf": [/*{
 		"browser": "safari",
 		"browser_version": "latest",
 		"os": "OS X",
@@ -77,6 +79,12 @@ module.exports = {
 		"browser_version": "latest",
 		"os": "OS X",
 		"os_version": "Mavericks"
+	},*/
+	{
+		"browser": "safari",
+		"browser_version": "latest",
+		"os": "OS X",
+		"os_version": "Yosemite"
 	}],
 	"ios": [{
 		"os": "ios",
@@ -91,11 +99,11 @@ module.exports = {
 		"os_version": "9.1",
 		"device": "iPhone 6S"
 	}],
-	"an": [{
+	"an": [/*{
 		"os": "android",
 		"os_version": "2.2",
 		"device": "Samsung Galaxy S"
-	},{
+	},*/{
 		"os": "android",
 		"os_version": "2.3",
 		"device": "Samsung Galaxy S2"
@@ -103,15 +111,15 @@ module.exports = {
 		"os": "android",
 		"os_version": "4.0",
 		"device": "Google Nexus"
-	},{
+	},/*{
 		"os": "android",
 		"os_version": "4.0",
 		"device": "Samsung Galaxy Note 10.1"
-	},{			
+	},*/{			
 		"os": "android",
 		"os_version": "4.1",
 		"device": "Samsung Galaxy S3"
-	},{
+	},/*{
 		"os": "android",
 		"os_version": "4.1",
 		"device": "Samsung Galaxy Note 2"
@@ -119,7 +127,7 @@ module.exports = {
 		"os": "android",
 		"os_version": "4.1",
 		"device": "Motorola Razr Maxx HD"
-	},{
+	},*/{
 		"os": "android",
 		"os_version": "4.2",
 		"device": "Google Nexus 4"
@@ -127,15 +135,15 @@ module.exports = {
 		"os": "android",
 		"os_version": "4.3",
 		"device": "Samsung Galaxy S4"
-	},{
+	},/*{
 		"os": "android",
 		"os_version": "4.3",
 		"device": "Samsung Galaxy Note 3"
-	},{
+	},*/{
 		"os": "android",
 		"os_version": "4.4",
 		"device": "Samsung Galaxy S5"
-	},{
+	}/*,{
 		"os": "android",
 		"os_version": "4.4",
 		"device": "Samsung Galaxy Tab 4 10.1"
@@ -143,5 +151,11 @@ module.exports = {
 		"os": "android",
 		"os_version": "4.4",
 		"device": "HTC One M8"
-	}]
+	}*/
+	,{
+		"os": "android",
+		"os_version": "5.0",
+		"device": "Google Nexus 6"
+	}
+]
 };

--- a/test/unit/js/visible.test.js
+++ b/test/unit/js/visible.test.js
@@ -151,39 +151,42 @@ test("check added elements", function() {
 	}
 });
 
-
-module("Visible wrapper Test", {
-	setup : function() {
-		$("#view").show();
-		this.inst = new eg.Visible( "#view", {
-			targetClass : "check_visible"
-		});
-		this.scroll = new IScroll("#view");
-	},
-	teardown : function() {
-		$("#view").hide();
-		this.scroll.destroy();
-		this.scroll = null;
-		this.inst.destroy();
-		this.inst = null;
-	}
-});
-
-test("When a iscroll position was changed", function(assert) {
-	var done = assert.async();
-	// Given
-	var self = this.inst;
-	// When
-	this.inst.check(-1);
-	this.inst.on("change", function(e) {
-		// Then
-		equal(e.visible.length, 5, "visible element length (5)");
-		equal(e.invisible.length, 7, "invisible element length (7)");
-		done();
+// Run test only when IScroll works
+if(document.querySelector && window.addEventListener) {
+	module("Visible wrapper Test", {
+		setup : function() {
+			$("#view").show();
+			this.inst = new eg.Visible( "#view", {
+				targetClass : "check_visible"
+			});
+			this.scroll = new IScroll("#view");
+		},
+		teardown : function() {
+			$("#view").hide();
+			this.scroll.destroy();
+			this.scroll = null;
+			this.inst.destroy();
+			this.inst = null;
+		}
 	});
-	this.scroll.scrollTo(0, -400,0);
-	self.check(200);
-});
+	
+	test("When a iscroll position was changed", function(assert) {
+		var done = assert.async();
+		// Given
+		var self = this.inst;
+		// When
+		this.inst.check(-1);
+		this.inst.on("change", function(e) {
+			// Then
+			equal(e.visible.length, 5, "visible element length (5)");
+			equal(e.invisible.length, 7, "invisible element length (7)");
+			done();
+		});
+		this.scroll.scrollTo(0, -400,0);
+		self.check(200);
+	});	
+}
+
 
 module("Visible Test when unsupported getElementsByClassName", {
 	setup : function() {


### PR DESCRIPTION
# Detail
* chore(all): improve test runner process with 2 browserstack vm  …
    * with "grunt browserstack" command, test will run by browser using 1 vm once.

    <img width="836" alt="screen shot 2016-02-23 at 2 00 59 pm" src="https://cloud.githubusercontent.com/assets/3903575/13242547/334f116c-da39-11e5-9456-ac856d61be90.png">
    * with "grunt browserstack:modulename" command, test will run by target module using 2 vm once.

    <img width="543" alt="screen shot 2016-02-23 at 2 29 57 pm" src="https://cloud.githubusercontent.com/assets/3903575/13242616/fb5ad2ea-da39-11e5-93f9-6f7bfcfb0beb.png">

* test(visible): Run test with iScroll only when iScroll works for old IE (IE 7, 8)

# Issue
#137 #139 

# Preferred reviewer
@netil @sculove 