### PR TITLE
Persist#173: Delete key in storage while setting with empty values

### DIFF
--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -158,7 +158,13 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 
 	function setStateByKey(key, data) {
 		var beforeData = getState();
-		beforeData[key] = data;
+
+		if (data === null || typeof data === "undefined" || data === "") {
+			delete beforeData[key];
+		} else {
+			beforeData[key] = data;
+		}
+
 		setState(beforeData);
 	}
 

--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -169,9 +169,10 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 	}
 
 	/**
-	* Save current state
+	* Save current state.
 	* @ko 인자로 넘긴 현재 상태정보를 저장한다.
 	* @method jQuery.persist
+	* @deprecated since version 1.2.0
 	* @support {"ie": "9+", "ch" : "latest", "ff" : "1.5+",  "sf" : "latest", "ios" : "7+", "an" : "2.2+ (except 3.x)"}
 	* @param {Object} state State object to be stored in order to restore UI component's state <ko>UI 컴포넌트의 상태를 복원하기위해 저장하려는 상태 객체</ko>
 	* @example
@@ -185,6 +186,7 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 	* Return current state
 	* @ko 인자로 넘긴 현재 상태정보를 반환한다.
 	* @method jQuery.persist
+	* @deprecated since version 1.2.0
 	* @return {Object} state Stored state object <ko>복원을 위해 저장되어있는 상태 객체</ko>
 	* @example
 	$("a").on("click",function(e){

--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -158,13 +158,7 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 
 	function setStateByKey(key, data) {
 		var beforeData = getState();
-
-		if (data === null || typeof data === "undefined" || data === "") {
-			delete beforeData[key];
-		} else {
-			beforeData[key] = data;
-		}
-
+		beforeData[key] = data;
 		setState(beforeData);
 	}
 

--- a/test/unit/js/persist.test.js
+++ b/test/unit/js/persist.test.js
@@ -7,6 +7,10 @@ function noop() {};
 
 module("persist: mock", {
 	setup: function() {
+		console.oldWarn = console.warn;
+		console.warn = function(msg){
+		};
+
 		this.data = {
 			"scrollTop": 100
 		};
@@ -286,7 +290,6 @@ test("persist : save state data by key, get state data by key", function() {
 $.each(['{', '[ 1,2,3 ]', '1', '1.234', '"123"'], function(i, v) {
 	test("show warning message for storage polloution with value that can be parsed: "+ v, function() {	
 		// Given		
-		console.oldWarn = console.warn;
 		var callCount = 0;
 		console.warn = function(msg){
 			callCount++;


### PR DESCRIPTION
## Issue
#172 
#173 

## Details
* Deprecate eg.persist() method without key
* Delete key in storage while setting with empty values( null, undefined, empty string)
* Hide warning messages while running unit test.

## Preferred reviewers
@netil @sculove 