### PR TITLE
fix(rotate): Rotate event is not fired In certain cases

### DIFF
--- a/src/customEvent/rotate.js
+++ b/src/customEvent/rotate.js
@@ -89,8 +89,6 @@ eg.module("rotate", ["jQuery", eg, window, document], function($, ns, global, do
 					vertical = false;
 				}
 			}
-
-			beforeScreenWidth = screenWidth;
 		} else {
 			degree = global.orientation;
 			if (degree === 0 || degree === 180) {
@@ -110,6 +108,7 @@ eg.module("rotate", ["jQuery", eg, window, document], function($, ns, global, do
 		if (isMobile) {
 			if (beforeVertical !== currentVertical) {
 				beforeVertical = currentVertical;
+				beforeScreenWidth = doc.documentElement.clientWidth;
 				$(global).trigger("rotate");
 			}
 		}
@@ -140,7 +139,6 @@ eg.module("rotate", ["jQuery", eg, window, document], function($, ns, global, do
 					// When width value wasn't changed after firing orientationchange, then call handler again after 300ms.
 					return false;
 				}
-				beforeScreenWidth = screenWidth;
 			}
 
 			global.clearTimeout(rotateTimer);

--- a/src/customEvent/rotate.js
+++ b/src/customEvent/rotate.js
@@ -34,6 +34,14 @@ eg.module("rotate", ["jQuery", eg, window, document], function($, ns, global, do
 	var agent = ns.agent();
 	var isMobile = /android|ios/.test(agent.os.name);
 
+	if (!isMobile) {
+		ns.isPortrait = function() {
+			return;
+		};
+
+		return;
+	}
+
 	/**
 	 * Return event name string for orientationChange according browser support
 	 */

--- a/test/manual/rotate.html
+++ b/test/manual/rotate.html
@@ -18,6 +18,12 @@
  <div id="layer"></div>
  <script>
 $(document).ready(function(){
+	$(window).on("resize", function() { 
+		if (eg.isPortrait()) { 
+			//do something...Test if call of isPortrait() makes side effects.
+		}
+	}); 
+
 	$(window).on("rotate",function(e){
 		$("#layer").text(e.isVertical?"vertical":"horizontal");
 	});

--- a/test/unit/js/rotate.test.js
+++ b/test/unit/js/rotate.test.js
@@ -511,3 +511,28 @@ test("If eg.isPortrait() affect the rotate event not to be fired.", function() {
   ok(!isVertical1, "Does isVertical return false?");
   ok(!isVertical2, "Does rotate event handler get horizontal?");
 });
+
+test("orientationChange : mac(PC) ", function() {
+  // Given
+  var agent = eg.agent();
+  agent.os = {
+    name: "mac",
+  };
+
+  var method = eg.invoke("rotate",[jQuery, null, this.fakeWindow, this.fakeDocument]);
+
+  // When
+  // Then
+  equal(method, null, "Invocation of rotate in mac Browser returns null");
+
+  //Given
+  agent.os = {
+    name: "windows",
+  };
+
+  method = eg.invoke("rotate",[jQuery, null, this.fakeWindow, this.fakeDocument]);
+
+  // When
+  // Then
+  equal(method, null, "Invocation of rotate in windows Browser returns null");
+});

--- a/test/unit/js/rotate.test.js
+++ b/test/unit/js/rotate.test.js
@@ -176,7 +176,7 @@ test("isVertical : If event is resize then sencond times call. and stay.", funct
   var isVertical = method.isVertical();
 
   // Then
-  equal(isVertical,null);
+  equal(isVertical,true);
 });
 
 test("isVertical : If event is resize then sencond times call. and rotate horizontal.", function() {
@@ -441,4 +441,73 @@ test("test using isPortrait first", function() {
 
   // Then
   equal(typeof val,"boolean");
+});
+
+test("If eg.isPortrait() affect the rotate event not to be fired.", function() {
+  // Given
+  var isCall = false;
+  var isVertical1 = false;
+  var isVertical2 = false;
+  var agent = eg.agent();
+  agent.os = {
+    name: "android",
+    version: "2.1"
+  };
+
+  delete this.fakeWindow.onorientationchange;
+  this.fakeWindow.resize = "resize";
+
+  this.fakeDocument.documentElement.clientWidth =  200;
+  this.fakeDocument.documentElement.clientHeight =  100;
+
+  var method = eg.invoke("rotate",[jQuery, null, this.fakeWindow, this.fakeDocument]);
+  $(this.fakeWindow).on("rotate",function(e){
+    isCall = true;
+    isVertical2 = e.isVertical;
+  });
+
+  // When
+  this.fakeDocument.documentElement.clientWidth =  100;
+  this.fakeDocument.documentElement.clientHeight =  200;
+
+  // isVertical() should not affect isVertical2.
+  isVertical1 = method.isVertical();
+
+  method.handler({
+    type : "resize"
+  });
+  this.clock.tick( 10 );
+
+  // Then
+  ok(isCall, "rotate event is fired by resize");
+  ok(isVertical1, "Does isVertical return true?");
+  ok(isVertical2, "Does rotate event handler get vertical?");
+
+  // When
+  isCall = false;
+  agent.os = {
+    name: "android",
+    version: "4.3"
+  };
+  this.fakeWindow.onorientationchange = noop;
+  this.fakeWindow.orientation = 90;
+
+  method = eg.invoke("rotate",[jQuery, null, this.fakeWindow, this.fakeDocument]);
+  $(this.fakeWindow).on("rotate",function(e){
+    isCall = true;
+    isVertical2 = e.isVertical;
+  });
+
+  // isVertical() should not affect isVertical2.
+  isVertical1 = method.isVertical();
+  method.handler({
+    type : "orientationchange"
+  });
+
+  this.clock.tick( 500 );
+
+  // Then
+  ok(isCall, "rotate event is fired by onorientationchange");
+  ok(!isVertical1, "Does isVertical return false?");
+  ok(!isVertical2, "Does rotate event handler get horizontal?");
 });


### PR DESCRIPTION
## Issue
#182 

## Details

```js
$(window).on("resize", function() { 
  if (eg.isPortrait()) { 
    //do something...
  }
}); 

$(window).on("rotate",function(e){
  // Not Fired		
});
```
isPortrait( ) affects the 'rotate' event firing. because When it is called, it changes the status value(`beforeScreenWidth`)   which is referenced by isVertical() (in next step) to decide if it is needed firing a "rotate" custom event.

## Preferred reviewers
@mixed , @sculove, @happyhj 

@mixed I tried to move `beforeScreenWidth` to the `handle( )` function as you told me. But I think `triggerRotate( )` is more proper because `beforeScreenWidth` must be changed after `isVertical` (by triggerRotate) is called.