### PR TITLE
fix(infiniteGrid): add defense code in setStatus method

### DIFF
--- a/src/infiniteGrid.js
+++ b/src/infiniteGrid.js
@@ -406,11 +406,14 @@ eg.module("infiniteGrid", ["jQuery", eg, window, document, "Outlayer"], function
 		 * @return {eg.InfiniteGrid} instance of itself<ko>자신의 인스턴스</ko>
 		 */
 		setStatus: function(status) {
-			this.core.element.style.cssText = status.cssText;
-			this.core.$element.html(status.html);
+			if (!status || $.isEmptyObject(status)) {
+				return this;
+			}
+			status.cssText && (this.core.element.style.cssText = status.cssText);
+			status.html && this.core.$element.html(status.html);
 			this.core.items = this.core.itemize(this.core.$element.children().toArray());
-			this.core.clone(this.core, status.core);
-			$.extend(this, status.data);
+			status.core && this.core.clone(this.core, status.core);
+			status.data && $.extend(this, status.data);
 			return this;
 		},
 		/**

--- a/src/infiniteGrid.js
+++ b/src/infiniteGrid.js
@@ -406,14 +406,15 @@ eg.module("infiniteGrid", ["jQuery", eg, window, document, "Outlayer"], function
 		 * @return {eg.InfiniteGrid} instance of itself<ko>자신의 인스턴스</ko>
 		 */
 		setStatus: function(status) {
-			if (!status || $.isEmptyObject(status)) {
+			if (!status || !status.cssText || !status.html ||
+				!status.core || !status.data) {
 				return this;
 			}
-			status.cssText && (this.core.element.style.cssText = status.cssText);
-			status.html && this.core.$element.html(status.html);
+			this.core.element.style.cssText = status.cssText;
+			this.core.$element.html(status.html);
 			this.core.items = this.core.itemize(this.core.$element.children().toArray());
-			status.core && this.core.clone(this.core, status.core);
-			status.data && $.extend(this, status.data);
+			this.core.clone(this.core, status.core);
+			$.extend(this, status.data);
 			return this;
 		},
 		/**

--- a/test/unit/js/infiniteGrid.test.js
+++ b/test/unit/js/infiniteGrid.test.js
@@ -368,6 +368,28 @@ module("infiniteGrid unit method Test", {
 	}
 });
 
+test("check object in restore method", function() {
+	// Given
+	this.inst = new eg.InfiniteGrid("#grid", {
+		"count" : 18
+	});
+
+	// When
+	var before = this.inst.getStatus();
+	this.inst.setStatus({});
+
+	// Then
+	equal(this.inst.core.element.style.cssText, before.cssText, "check cssText");
+	equal(this.inst.core.$element.html(), before.html, "check html");
+
+	// When
+	this.inst.setStatus();
+
+	// Then
+	equal(this.inst.core.element.style.cssText, before.cssText, "check cssText");
+	equal(this.inst.core.$element.html(), before.html, "check html");
+});
+
 test("restore status", function(assert) {
 	var done = assert.async();
 	var $el,


### PR DESCRIPTION
## Issue
#161 

## Details
- When the parameter  is not appropriate for setStatus method, a script error is fired.


## Preferred reviewers
@jongmoon @happyhj 