### PR TITLE
fix(persist): don't show warning message on clean storage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,7 @@ module.exports = function(grunt) {
 	grunt.registerTask("build", ["concat", "uglify", "clean:pkgd", "docBuild"]);
 	grunt.registerTask("default", ["jshint", "jscs", "build", "test"]);
 	grunt.registerTask("check", ["jshint", "jscs", "test"]);
+	grunt.registerTask("lint", ["jshint", "jscs"]);
 	grunt.registerTask("changelog", function(after, before) {
 		grunt.task.run.apply(grunt.task, ["exec:changelog:" + [ after, before ].join(":") ]);
 	});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "grunt check",
     "fakeserver": "node test/fakeserver/app.js",
-    "prepush": "grunt check",
+    "prepush": "grunt lint",
     "commitmsg": "node config/validate-commit-msg.js"
   },
   "repository": {

--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -89,6 +89,13 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 		var stateStr = storage ?
 			storage.getItem(location.href + CONST_PERSIST) : history.state;
 
+/*
+		// the storage is clean
+		if (stateStr === null) {
+			return {};
+		}
+*/
+
 		// "null" is not a valid
 		var isValidStateStr = typeof stateStr === "string" &&
 									stateStr.length > 0 && stateStr !== "null";

--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -89,12 +89,10 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 		var stateStr = storage ?
 			storage.getItem(location.href + CONST_PERSIST) : history.state;
 
-/*
 		// the storage is clean
 		if (stateStr === null) {
 			return {};
 		}
-*/
 
 		// "null" is not a valid
 		var isValidStateStr = typeof stateStr === "string" &&

--- a/test/unit/js/persist.test.js
+++ b/test/unit/js/persist.test.js
@@ -301,8 +301,8 @@ $.each(['{', '[ 1,2,3 ]', '1', '1.234', '"123"'], function(i, v) {
 
 		var isNoExceptionThrown = true;
 		if(isSupportStorage) {
-			sessionStorage.setItem("KEY___persist___", v);
-			localStorage.setItem("KEY___persist___", v);
+			sessionStorage.setItem(location.href + "___persist___", v);
+			localStorage.setItem(location.href + "___persist___", v);
 		} else if(isSupportState) {
 			history.replaceState(v, document.title, location.href);	
 		}


### PR DESCRIPTION
## Issue
#197
#199

## Details
chore(all): Remove unit testing task from prepush hook

* add listing grunt task "grunt lint"
* modify prepush hook to use "grunt lint" command 

fix(persist): don't show warning message on clean storage

* Make persist don't show warning message when storage is clean.

## Preferred reviewers
@naver/egjs-committers  @sculove @jongmoon 
