### PR TITLE
fix(MovableCoord): Unlock interrupt flag after no move.

### DIFF
--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -446,6 +446,8 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 
 				if (pos[0] !== destPos[0] || pos[1] !== destPos[1]) {
 					this._animateTo(destPos, null, e || null);
+				} else {
+					this._setInterrupt(false);
 				}
 			}
 			this._status.moveDistance = null;

--- a/test/unit/js/movableCoord.test.js
+++ b/test/unit/js/movableCoord.test.js
@@ -987,6 +987,47 @@ test("interrupt test after tap gesture", function(assert) {
     	});
 });
 
+test("interrupt test. Second 'MovableCoord move' can be available after 'no move' by first MovableCoord move", function(assert) {
+	var EXPECTED_RELEASE_COUNT = 2;
+	var releaseCount = 0;
+	var done = assert.async();
+	//Given
+	var el = $("#area").get(0);
+
+	this.inst.on( {
+		"release" : function(e) {
+			releaseCount++;
+		}
+	});
+
+	this.inst.bind(el, {
+		interruptable: false
+	});
+
+	this.inst.options.bounce = [0, 0, 0, 0];
+
+	// When
+	Simulator.gestures.pan(el, {
+		pos: [100, 100],
+            deltaX: -10,
+            deltaY: 0,
+            duration: 1000,
+            easing: "linear"
+	}, function() {
+		Simulator.gestures.pan(el, {
+			pos: [100, 100],
+            deltaX: 0,
+            deltaY: -10,
+            duration: 1000,
+            easing: "linear"
+		}, function() {
+			equal(releaseCount, EXPECTED_RELEASE_COUNT, 
+				"Second 'MovableCoord move' can be available after 'No move' by first MovableCoord move")
+			done();
+		});
+    });
+});
+
 module("movableCoord event Test", {
 	setup : function() {
 		this.inst = new eg.MovableCoord( {


### PR DESCRIPTION
## Issue
#195 

## Details
Fix the bug which prevent user interaction after no change move.

When user try to move position but If no changes occurs _(caused by MC.DIRECTION_XXX FLAG or insufficient user movement for moving position)_, then **there's no chance to set interrupt flag to false**. It makes user interaction unavailable.

## Preferred reviewers
@sculove @happyhj 