### PR TITLE
chore(all): Remove unit testing task from prepush hook

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,7 @@ module.exports = function(grunt) {
 	grunt.registerTask("build", ["concat", "uglify", "clean:pkgd", "docBuild"]);
 	grunt.registerTask("default", ["jshint", "jscs", "build", "test"]);
 	grunt.registerTask("check", ["jshint", "jscs", "test"]);
+	grunt.registerTask("lint", ["jshint", "jscs"]);
 	grunt.registerTask("changelog", function(after, before) {
 		grunt.task.run.apply(grunt.task, ["exec:changelog:" + [ after, before ].join(":") ]);
 	});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "grunt check",
     "fakeserver": "node test/fakeserver/app.js",
-    "prepush": "grunt check",
+    "prepush": "grunt lint",
     "commitmsg": "node config/validate-commit-msg.js"
   },
   "repository": {


### PR DESCRIPTION
## Issue
#197

## Details
chore(all): Remove unit testing task from prepush hook

* add listing grunt task "grunt lint"
* modify prepush hook to use "grunt lint" command 

## Preferred reviewers
@naver/egjs-committers  @sculove   @jongmoon 
