### PR TITLE
fix(persist): don't show warning message on clean storage

### DIFF
--- a/src/plugin/persist.js
+++ b/src/plugin/persist.js
@@ -89,6 +89,11 @@ eg.module("persist", ["jQuery", eg, window, document], function($, ns, global, d
 		var stateStr = storage ?
 			storage.getItem(location.href + CONST_PERSIST) : history.state;
 
+		// the storage is clean
+		if (stateStr === null) {
+			return {};
+		}
+
 		// "null" is not a valid
 		var isValidStateStr = typeof stateStr === "string" &&
 									stateStr.length > 0 && stateStr !== "null";

--- a/test/unit/js/persist.test.js
+++ b/test/unit/js/persist.test.js
@@ -301,8 +301,8 @@ $.each(['{', '[ 1,2,3 ]', '1', '1.234', '"123"'], function(i, v) {
 
 		var isNoExceptionThrown = true;
 		if(isSupportStorage) {
-			sessionStorage.setItem("KEY___persist___", v);
-			localStorage.setItem("KEY___persist___", v);
+			sessionStorage.setItem(location.href + "___persist___", v);
+			localStorage.setItem(location.href + "___persist___", v);
 		} else if(isSupportState) {
 			history.replaceState(v, document.title, location.href);	
 		}


### PR DESCRIPTION
## Issue
#199

## Details
fix(persist): don't show warning message on clean storage

* Make persist don't show warning message when storage is clean.

## Preferred reviewers
@naver/egjs-committers  @mixed @jongmoon 
