### PR TITLE
chore(commit): Bypass keyword change WIP to skip

### DIFF
--- a/config/validate-commit-msg.js
+++ b/config/validate-commit-msg.js
@@ -17,7 +17,7 @@ var util = require('util');
 var MAX_TITLE_LENGTH = 50;
 var MAX_LENGTH = 100;
 var PATTERN = /^(?:fixup!\s*)?(\w*)(\(([\w\$\,\.\*/-]*)\))?\: (.*)$/;
-var IGNORED = /^WIP\:/;
+var IGNORED = /^skip\:/;
 var TYPES = {
   feat: true,
   fix: true,


### PR DESCRIPTION
## Issue

## Details
Keyword skip commit log validation that have changed `WIP` to `skip`.

## Preferred reviewers
@naver/egjs-dev 
