### PR TITLE
chore(all): support jsdoc setting to support ko tag

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -30,6 +30,6 @@
     "markdown": {
         "parser": "gfm",
         "hardwrap": true,
-        "tags": ["examples"]
+        "tags": ["examples", "ko"]
     }
 }


### PR DESCRIPTION
## Issue
#271

## Details
Support markdown on @ko Tag in jsdoc documentation

like below,
```html
/**
 * @ko 안녕하세요! **굵은글씨**도 가능하고 이미지도 연결 할 수 있어요 ![YourImage](http://....)
 */
```

## Preferred reviewers
@sculove @naver/egjs-dev
