### PR TITLE
fix(MovableCoord): fire release event

### DIFF
--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -183,14 +183,12 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 						this._subOptions = options;
 						this._status.curHammer = hammer;
 						this._panstart(e);
-					} else if (e.isFinal && e.direction !== MC.DIRECTION_NONE &&
-						!(e.direction & this._subOptions.direction)) {
-						// Although direction of movement is different from options.direction, MC should fire 'release' event.
+					} else if (e.isFinal) {
+						// substitute .on("panend tap", this._panend); Because it(tap, panend) cannot catch vertical(horizontal) movement on HORIZONTAL(VERTICAL) mode.
 						this._panend(e);
 					}
 				}, this))
-				.on("panstart panmove", this._panmove)
-				.on("panend tap", this._panend);
+				.on("panstart panmove", this._panmove);
 		},
 
 		_detachHammerEvents: function(hammer) {
@@ -415,7 +413,7 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 			}
 
 			// Abort the animating post process when "tap" occurs
-			if (e.type === "tap") {
+			if (e.distance === 0 /*e.type === "tap"*/) {
 				this._setInterrupt(false);
 				this.trigger("release", {
 					depaPos: pos.concat(),

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -185,7 +185,7 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 		},
 
 		_detachHammerEvents: function(hammer) {
-			hammer.off("hammer.input panstart panmove panend tap");
+			hammer.off("hammer.input panstart panmove panend");
 		},
 
 		_convertInputType: function(inputType) {

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -147,17 +147,10 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 				var hammer = new HM.Manager(el, {
 						recognizers: [
 							[
-								HM.Tap, {
-
-									// for long tap
-									time: 30000
-								}
-							],
-							[
 								HM.Pan, {
 									direction: subOptions.direction,
 									threshold: 0
-								}, ["tap"]
+								}
 							]
 						],
 

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -183,6 +183,9 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 						this._subOptions = options;
 						this._status.curHammer = hammer;
 						this._panstart(e);
+					} else if (e.isFinal && !(e.direction & this._subOptions.direction)) {
+						// Although movement is other direction, MC should fire 'release' events.
+						this._panend(e);
 					}
 				}, this))
 				.on("panstart panmove", this._panmove)

--- a/src/movableCoord.js
+++ b/src/movableCoord.js
@@ -183,8 +183,9 @@ eg.module("movableCoord", ["jQuery", eg, window, "Hammer"], function($, ns, glob
 						this._subOptions = options;
 						this._status.curHammer = hammer;
 						this._panstart(e);
-					} else if (e.isFinal && !(e.direction & this._subOptions.direction)) {
-						// Although movement is other direction, MC should fire 'release' events.
+					} else if (e.isFinal && e.direction !== MC.DIRECTION_NONE &&
+						!(e.direction & this._subOptions.direction)) {
+						// Although direction of movement is different from options.direction, MC should fire 'release' event.
 						this._panend(e);
 					}
 				}, this))

--- a/test/unit/js/movableCoord.test.js
+++ b/test/unit/js/movableCoord.test.js
@@ -1161,6 +1161,64 @@ test("movement direction test (DIRECTION_VERTICAL)", function(assert) {
     	});
 });
 
+test("cross movement test (vertical movement on DIRECTION_HORIZONTAL)", function(assert) {
+	var done = assert.async();
+	//Given
+	var el = $("#area").get(0);
+
+	/**
+	 * release event must be expired although the direction is not concerned
+	 */
+	this.inst.on({
+		"release" : function(e) {
+			//Then
+			equal(e.destPos[0], 0);
+			equal(e.destPos[1], 0);
+		}
+	});
+	this.inst.bind(el, {
+		direction : eg.MovableCoord.DIRECTION_HORIZONTAL
+	});
+
+	// When
+	Simulator.gestures.pan(el, {
+		pos: [0, 0],
+            deltaX: 0,
+            deltaY: 10,
+            duration: 1000,
+            easing: "linear"
+	}, done);
+});
+
+test("cross movement test (horizontal movement on DIRECTION_VERTICAL)", function(assert) {
+	var done = assert.async();
+	//Given
+	var el = $("#area").get(0);
+
+	/**
+	 * release event must be expired although the direction is not concerned
+	 */
+	this.inst.on({
+		"release" : function(e) {
+			//Then
+			equal(e.destPos[0], 0);
+			equal(e.destPos[1], 0);
+		}
+	});
+	this.inst.bind(el, {
+		direction : eg.MovableCoord.DIRECTION_VERTICAL
+	});
+
+	// When
+	Simulator.gestures.pan(el, {
+		pos: [0, 0],
+            deltaX: 10,
+            deltaY: 0,
+            duration: 1000,
+            easing: "linear"
+	}, done);
+});
+
 test("_convertInputType (support touch)", function() {
 	// Given
 	var globalWithToucnSupport = {


### PR DESCRIPTION
## Issue
#288 

## Details

Although direction of movement is different from options.direction, MC should fire 'release' event.

## Preferred reviewers
@sculove, @netil, @mixed 

@netil it's related with `eg.flicking`
