### PR TITLE
fix(infiniteGrid): fix image check module in IE9

### DIFF
--- a/src/infiniteGrid.js
+++ b/src/infiniteGrid.js
@@ -824,8 +824,10 @@ eg.module("infiniteGrid", ["jQuery", eg, window, document, "Outlayer"], function
 				$(e.target).off("load error");
 				checkCount <= 0 && callback && self.core && callback.apply(self);
 			};
+			var $el;
 			$.each(needCheck, function(k, v) {
-				$(v).on("load error", onCheck);
+				$el = $(v);
+				$el.attr("src", $el.attr("src")).on("load error", onCheck);
 			});
 		},
 		/**


### PR DESCRIPTION
## Issue
#309 

## Details
IE9 couldn't unaware `load` event of images 

## Preferred reviewers
@kishu 