### PR TITLE
feat(Flicking): Remove .getTotalCount() and index prop event

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -1030,7 +1030,6 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 
 			return this.trigger(conf.eventPrefix + name, $.extend({
 				eventType: name,
-				index: panel.currIndex,
 				no: panel.currNo,
 				direction: conf.touch.direction
 			}, param));
@@ -1177,17 +1176,6 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		 */
 		getPrevIndex: function (physical) {
 			return this._getElement(this._conf.dirData[1], false, physical);
-		},
-
-		/**
-		 * Get total panel count
-		 * @ko 전체 패널의 개수를 반환한다.
-		 * @method eg.Flicking#getTotalCount
-		 * @param {Boolean} [physical=false] Boolean to get physical or logical index (true : physical, false : logical) <ko>물리적/논리적 값 인덱스 불리언(true: 물리적, false: 논리적)</ko>
-		 * @return {Number} Number Count of all elements <ko>모든 패널 요소 개수</ko>
-		 */
-		getTotalCount: function (physical) {
-			return this._conf.panel[ physical ? "count" : "origCount" ];
 		},
 
 		/**

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -651,8 +651,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
-			 * @param {Number} param.index Current panel physical index <ko>현재 패널의 물리적 인덱스</ko>
-			 * @param {Number} param.no Current panel logical position <ko>현재 패널의 논리적 인덱스</ko>
+			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 * @param {Array} param.pos Departure coordinate <ko>출발점 좌표</ko>
 			 * @param {Number} param.pos.0 Departure x-coordinate <ko>x 좌표</ko>
@@ -775,8 +774,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
-			 * @param {Number} param.index Current panel physical index <ko>현재 패널의 물리적 인덱스</ko>
-			 * @param {Number} param.no Current panel logical position <ko>현재 패널의 논리적 인덱스</ko>
+			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 * @param {Array} param.depaPos Departure coordinate <ko>출발점 좌표</ko>
 			 * @param {Number} param.depaPos.0 Departure x-coordinate <ko>x 좌표</ko>
@@ -809,8 +807,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
-			 * @param {Number} param.index Current panel physical index <ko>현재 패널의 물리적 인덱스</ko>
-			 * @param {Number} param.no Current panel logical position <ko>현재 패널의 논리적 인덱스</ko>
+			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 */
 			customEvent.restore && this._triggerEvent(EVENTS.restore);
@@ -835,8 +832,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				 * @event
 				 * @param {Object} param
 				 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
-				 * @param {Number} param.index Current panel physical index <ko>현재 패널의 물리적 인덱스</ko>
-				 * @param {Number} param.no Current panel logical position <ko>현재 패널의 논리적 인덱스</ko>
+				 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 				 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 				 * @param {Array} param.depaPos Departure coordinate <ko>출발점 좌표</ko>
 				 * @param {Number} param.depaPos.0 Departure x-coordinate <ko>x 좌표</ko>
@@ -865,8 +861,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				 * @event
 				 * @param {Object} param
 				 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
-				 * @param {Number} param.index Current panel physical index <ko>현재 패널의 물리적 인덱스</ko>
-				 * @param {Number} param.no Current panel logical position <ko>현재 패널의 논리적 인덱스</ko>
+				 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 				 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 				 */
 				panel.changed && this._triggerEvent(EVENTS.flickEnd);

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -545,33 +545,6 @@ QUnit.test("getAllElements()", function(assert) {
 	assert.deepEqual(elements.length, inst.$container.children().length, "Returned all panel elements?");
 });
 
-QUnit.test("getTotalCount()", function(assert) {
-	// Given
-	this.create("#mflick1");
-	this.create("#mflick2-1", { circular : true });
-
-	var inst = this.inst[0];
-
-	// When
-	var counts = inst.getTotalCount();
-
-	// Then
-	assert.deepEqual(counts, inst.$container.children().length, "Return total panel elements count?");
-
-	// Given
-	inst = this.inst[1];
-
-	// When
-	counts = inst.getTotalCount();
-
-	// Then
-	assert.ok(counts < inst.$container.children().length, "When circular options is set, the elements count is less than physical elements count");
-
-	// When
-	counts = inst.getTotalCount(true);
-	assert.deepEqual(counts, inst.$container.children().length, "Returned physical elements total count?");
-});
-
 QUnit.test("isPlaying()", function(assert) {
 	var done = assert.async();
 
@@ -1226,7 +1199,6 @@ QUnit.test("When changes panel normally", function(assert) {
 					eventFired.push(type);
 
 					panel[type] = {
-						index: e.index,
 						no: e.no,
 						getElement: this.getElement(),
 						getIndex: this.getIndex(),
@@ -1247,7 +1219,6 @@ QUnit.test("When changes panel normally", function(assert) {
 			panel: {},
 			inst: f,
 			currentPanel: {
-				index: f._conf.panel.currIndex,
 				no: f._conf.panel.currNo,
 				getElement: f.getElement(),
 				getIndex: f.getIndex(),
@@ -1270,7 +1241,7 @@ QUnit.test("When changes panel normally", function(assert) {
 
 			// Then
 			setTimeout(function() {
-			assert.deepEqual(eventOrder, eventFired, "Custom events are fired in correct order");
+				assert.deepEqual(eventOrder, eventFired, "Custom events are fired in correct order");
 
 				var isCircular = inst.options.circular;
 
@@ -1313,7 +1284,7 @@ QUnit.test("When changes panel normally", function(assert) {
 
 					} else {
 						$.each(oPanel, function(x) {
-						assert.deepEqual(oPanel[x], currentPanel[x], "The value from '"+ x +"', shouldn't be changed during '"+ i +"' event.");
+							assert.deepEqual(oPanel[x], currentPanel[x], "The value from '"+ x +"', shouldn't be changed during '"+ i +"' event.");
 						});
 					}
 				});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#229 

## Details
<!-- Detailed description of the change/feature -->
 - Removed .getTotalCount()
 - Removed index property value from custom event object

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove @kishu 