### PR TITLE
fix(Flicking): Correct panel sizing on padding

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -236,22 +236,22 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			this._setPadding(padding, true);
 			var sizeValue = this._getDataByDirection([ panel.size, "100%" ]);
 
-			// panels' css values
-			$children.addClass(prefix + "-panel").css({
-				position: "absolute",
-				width: sizeValue[0],
-				height: sizeValue[1],
-				top: 0,
-				left: 0
-			});
-
 			// create container element
 			cssValue = "position:relative;z-index:2000;width:100%;height:100%;" +
 				(horizontal ? "" : "top:0;");
 
 			this.$container = $children.wrapAll(
 				"<div class='" + prefix + "-container' style='" + cssValue + "' />"
-			).parent();
+
+			// panels' css values
+			).addClass(prefix + "-panel").css({
+				position: "absolute",
+				width: sizeValue[0],
+				height: sizeValue[1],
+				boxSizing: "border-box",
+				top: 0,
+				left: 0
+			}).parent();
 
 			if (this._addClonePanels()) {
 				panelCount = panel.count = (

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -79,10 +79,20 @@ var hooks = {
 QUnit.module("Initialization", hooks);
 QUnit.test("Check for the initialization", function(assert) {
 	// Given
-	var inst = this.create("#mflick1");
+	var inst1 = this.create("#mflick1");
+	var inst2 = this.create("#mflick2", { horizontal: false });
 
 	// Then
-	assert.deepEqual(inst.$container.width(), inst.$container.parent().width(), "Then panel container was added and the width is same as wrapper element.");
+	assert.deepEqual(inst1.$container.width(), inst1.$container.parent().width(), "Then panel container was added and the width is same as wrapper element.");
+	assert.deepEqual(inst2.$container.height(), inst1.$container.parent().height(), "Then panel container was added and the height is same as wrapper element.");
+
+	// Given
+	inst1._conf.panel.$list.css("padding", "0 20px");
+	inst2._conf.panel.$list.css("padding", "20px 0");
+
+	// Then
+	assert.equal(inst1._conf.panel.size, inst1._conf.panel.$list.outerWidth(), "The panel should maintain same width as wrapper element.");
+	assert.equal(inst2._conf.panel.size, inst2._conf.panel.$list.outerHeight(), "The panel should maintain same height as wrapper element.");
 });
 
 QUnit.module("Setting options", hooks);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
 #226 

## Details
<!-- Detailed description of the change/feature -->
Giving boxSizing 'border-box' prop to panels to include border & padding within width/height value of panel.
https://developer.mozilla.org/en/docs/Web/CSS/box-sizing

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@jongmoon @happyhj 


