### PR TITLE
fix(pauseResume): Don't convert relative values of transform string.

### DIFF
--- a/src/hook/pauseResume.js
+++ b/src/hook/pauseResume.js
@@ -51,6 +51,12 @@ eg.module("pauseResume", ["jQuery"], function($) {
 			var markIndex;
 			var sign;
 
+			// DO NOT SUPPORT TRANSFORM YET
+			// TODO: convert from relative value to absolute value on transform
+			if (propName === "transform") {
+				continue;
+			}
+
 			//If it has a absoulte value.
 			if (typeof propValue !== "string" ||
 				(markIndex = propValue.search(/[+|-]=/)) < 0) {


### PR DESCRIPTION
## Issue
#340 

## Details
Do not convert transform's relative values to absolute values. Because pauseResume does not support "transform" property yet.

We will going to enhance this issue on #242 . Before this, we need temporary measure.

## Preferred reviewers
@naver/egjs-dev