### PR TITLE
fix(Flicking): Prevent API move call during touch hold

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -184,7 +184,8 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 					destPos: [0, 0],	// destination x,y coordinate
 					distance: 0,		// touch distance pixel of start to end touch
 					direction: null,	// touch direction
-					lastPos: 0			// to determine move on holding
+					lastPos: 0,			// to determine move on holding
+					holding: false
 				},
 				customEvent: {			// for custom events value
 					flick: true,
@@ -625,8 +626,11 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		 * 'hold' event handler
 		 */
 		_holdHandler: function (e) {
-			this._conf.touch.holdPos = e.pos;
-			this._conf.panel.changed = false;
+			var conf = this._conf;
+
+			conf.touch.holdPos = e.pos;
+			conf.touch.holding = true;
+			conf.panel.changed = false;
 
 			this._adjustContainerCss("start", e.pos);
 		},
@@ -708,6 +712,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				pos[posIndex] = Math.round(pos[posIndex] / panelSize) * panelSize;
 
 			touch.distance === 0 && this._adjustContainerCss("end");
+			touch.holding = false;
 
 			this._setPointerEvents();  // for "click" bug
 		},
@@ -1183,10 +1188,11 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		 * @param {Number} duration
 		 */
 		_movePanel: function (next, duration) {
-			var panel = this._conf.panel;
+			var conf = this._conf;
+			var panel = conf.panel;
 			var options = this.options;
 
-			if (panel.animating) {
+			if (panel.animating || conf.touch.holding) {
 				return;
 			}
 
@@ -1249,7 +1255,8 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		 * @return {eg.Flicking} instance of itself<ko>자신의 인스턴스</ko>
 		 */
 		moveTo: function (no, duration) {
-			var panel = this._conf.panel;
+			var conf = this._conf;
+			var panel = conf.panel;
 			var circular = this.options.circular;
 			var currentIndex = panel.index;
 			var indexToMove;
@@ -1257,7 +1264,8 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 
 			no = this._getNumValue(no, -1);
 
-			if (no < 0 || no >= panel.origCount || no === panel.no || panel.animating) {
+			if (no < 0 || no >= panel.origCount || no === panel.no ||
+				panel.animating || conf.touch.holding) {
 				return this;
 			}
 

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -1789,3 +1789,24 @@ QUnit.test("Custom event name with prefix: to handle jQuery plugin style", funct
 
 	assert.deepEqual(events, eventFired, "Events did fired correctly?");
 });
+
+QUnit.test("Disallow API move calls during touch hold", function(assert) {
+	var done = assert.async();
+
+	// Given
+	var el = $("#mflick1")[0];
+	var inst = this.create(el, { circular: true });
+	var index = [];
+
+	var interval = setInterval(function() {
+			index.push(inst.getIndex());
+			inst.next(100);
+		}, 200);
+
+	simulator(el, { pos: [ 200, 50], deltaX: -200, deltaY: 0, duration: 1000 }, function() {
+		clearInterval(interval);
+		assert.equal(index.length, index.filter(function(v) { return v === 0; }).length, "Panel shouldn't have to moved during touch hold.");
+
+		done();
+	});
+});


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#268 

## Details
<!-- Detailed description of the change/feature -->
Using touch.holding flag value, which is set true on ._holdHandler() and false on ._releaseHandler(),
to not execute according flag value.

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 