### PR TITLE
test(dev-env): Add browserSync task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
 		"clean": getConfig("clean"),
 		"gitinfo": grunt.task.run("exec:gitinfo"),
 		"banner": getConfig("banner"),
+		"browserSync": getConfig("browserSync"),
 		"exec": getConfig("exec"),
 		"concat": getConfig("concat"),
 		"copy": getConfig("copy"),

--- a/config/browserSync.js
+++ b/config/browserSync.js
@@ -1,0 +1,21 @@
+module.exports = {
+	bsFiles: {
+		src: [
+			"src/**",
+			"test/**",
+			"dist/**/*.js"
+		]
+	},
+	options: {
+		server: {
+			baseDir: "./",
+			directory: true
+		},
+		ui: {
+			port: 8080,
+			weinre: {
+				port: 9090
+			}
+		}
+	}
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "browserstack-runner": "^0.4.1",
     "egjs-jsdoc-template": "*",
     "grunt": "^0.4.5",
+    "grunt-browser-sync": "^2.2.0",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#344 

## Details
<!-- Detailed description of the change/feature -->
For ease of browser testing. 
The command below will run local server & launch browser from root.

```bash
grunt browserSync
```

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@naver/egjs-dev 

