### PR TITLE
feat(Flicking): Deprecate .getTotalCount() and index prop event

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -657,6 +657,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
+			 * @param {Number} param.index Current panel physical index (@deprecated since 1.3.0)<ko>현재 패널의 물리적 인덱스 (@deprecated since 1.3.0)</ko>
 			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 * @param {Array} param.pos Departure coordinate <ko>출발점 좌표</ko>
@@ -781,6 +782,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
+			 * @param {Number} param.index Current panel physical index (@deprecated since 1.3.0)<ko>현재 패널의 물리적 인덱스 (@deprecated since 1.3.0)</ko>
 			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 * @param {Array} param.depaPos Departure coordinate <ko>출발점 좌표</ko>
@@ -814,6 +816,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			 * @event
 			 * @param {Object} param
 			 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
+			 * @param {Number} param.index Current panel physical index (@deprecated since 1.3.0)<ko>현재 패널의 물리적 인덱스 (@deprecated since 1.3.0)</ko>
 			 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 			 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 			 */
@@ -839,6 +842,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				 * @event
 				 * @param {Object} param
 				 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
+				 * @param {Number} param.index Current panel physical index (@deprecated since 1.3.0)<ko>현재 패널의 물리적 인덱스 (@deprecated since 1.3.0)</ko>
 				 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 				 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 				 * @param {Array} param.depaPos Departure coordinate <ko>출발점 좌표</ko>
@@ -868,6 +872,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				 * @event
 				 * @param {Object} param
 				 * @param {String} param.eventType Name of event <ko>이벤트명</ko>
+				 * @param {Number} param.index Current panel physical index (@deprecated since 1.3.0)<ko>현재 패널의 물리적 인덱스 (@deprecated since 1.3.0)</ko>
 				 * @param {Number} param.no Current panel logical position <ko>패널 인덱스 번호</ko>
 				 * @param {Number} param.direction Direction of the panel move (see eg.MovableCoord.DIRECTION_* constant) <ko>플리킹 방향 (eg.MovableCoord.DIRECTION_* constant 확인)</ko>
 				 */
@@ -1026,6 +1031,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 
 			return this.trigger(conf.eventPrefix + name, $.extend({
 				eventType: name,
+				index: panel.currIndex,
 				no: panel.currNo,
 				direction: conf.touch.direction
 			}, param));
@@ -1172,6 +1178,18 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		 */
 		getPrevIndex: function (physical) {
 			return this._getElement(this._conf.dirData[1], false, physical);
+		},
+
+		/**
+		 * Get total panel count
+		 * @ko 전체 패널의 개수를 반환한다.
+		 * @method eg.Flicking#getTotalCount
+		 * @deprecated since 1.3.0
+		 * @param {Boolean} [physical=false] Boolean to get physical or logical index (true : physical, false : logical) <ko>물리적/논리적 값 인덱스 불리언(true: 물리적, false: 논리적)</ko>
+		 * @return {Number} Number Count of all elements <ko>모든 패널 요소 개수</ko>
+		 */
+		getTotalCount: function (physical) {
+			return this._conf.panel[ physical ? "count" : "origCount" ];
 		},
 
 		/**

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -555,6 +555,33 @@ QUnit.test("getAllElements()", function(assert) {
 	assert.deepEqual(elements.length, inst.$container.children().length, "Returned all panel elements?");
 });
 
+QUnit.test("getTotalCount()", function(assert) {
+	// Given
+	this.create("#mflick1");
+	this.create("#mflick2-1", { circular : true });
+
+	var inst = this.inst[0];
+
+	// When
+	var counts = inst.getTotalCount();
+
+	// Then
+	assert.deepEqual(counts, inst.$container.children().length, "Return total panel elements count?");
+
+	// Given
+	inst = this.inst[1];
+
+	// When
+	counts = inst.getTotalCount();
+
+	// Then
+	assert.ok(counts < inst.$container.children().length, "When circular options is set, the elements count is less than physical elements count");
+
+	// When
+	counts = inst.getTotalCount(true);
+	assert.deepEqual(counts, inst.$container.children().length, "Returned physical elements total count?");
+});
+
 QUnit.test("isPlaying()", function(assert) {
 	var done = assert.async();
 
@@ -1209,6 +1236,7 @@ QUnit.test("When changes panel normally", function(assert) {
 					eventFired.push(type);
 
 					panel[type] = {
+						index: e.index,
 						no: e.no,
 						getElement: this.getElement(),
 						getIndex: this.getIndex(),
@@ -1229,6 +1257,7 @@ QUnit.test("When changes panel normally", function(assert) {
 			panel: {},
 			inst: f,
 			currentPanel: {
+				index: f._conf.panel.currIndex,
 				no: f._conf.panel.currNo,
 				getElement: f.getElement(),
 				getIndex: f.getIndex(),


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#229

## Details
<!-- Detailed description of the change/feature -->
Revert of removed code from #326
Marked @deprecated JSDoc tag

Ref. https://github.com/naver/egjs/wiki/Deprecation-process

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 