### PR TITLE
feat(Flicking): Handle when container element is given

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -164,6 +164,11 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			var options = this.options;
 			var padding = options.previewPadding;
 
+			if ($children.length === 1 && $children.hasClass(options.prefix +"-container")) {
+				this.$container = $children;
+				$children = $children.children();
+			}
+
 			// config value
 			this._conf = {
 				panel: {
@@ -241,18 +246,23 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			cssValue = "position:relative;z-index:2000;width:100%;height:100%;" +
 				(horizontal ? "" : "top:0;");
 
-			this.$container = $children.wrapAll(
-				"<div class='" + prefix + "-container' style='" + cssValue + "' />"
+			if (this.$container) {
+				this.$container.attr("style", cssValue);
+			} else {
+				this.$container = $children.wrapAll(
+					"<div class='" + prefix + "-container' style='" + cssValue + "'>"
+				).parent();
+			}
 
 			// panels' css values
-			).addClass(prefix + "-panel").css({
+			$children.addClass(prefix + "-panel").css({
 				position: "absolute",
 				width: sizeValue[0],
 				height: sizeValue[1],
 				boxSizing: "border-box",
 				top: 0,
 				left: 0
-			}).parent();
+			});
 
 			if (this._addClonePanels()) {
 				panelCount = panel.count = (

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -164,7 +164,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			var options = this.options;
 			var padding = options.previewPadding;
 
-			if ($children.length === 1 && $children.hasClass(options.prefix +"-container")) {
+			if ($children.eq(0).hasClass(options.prefix + "-container")) {
 				this.$container = $children;
 				$children = $children.children();
 			}

--- a/test/unit/flicking.test.html
+++ b/test/unit/flicking.test.html
@@ -36,6 +36,20 @@
 		 </div>
 	 </div>
 
+	 <div id="mflick1-1" class="flick">
+		 <div class="eg-flick-container">
+			 <div style="background-color:#CC66CC">
+				 <p>Layer 0</p>
+			 </div>
+			 <div style="background-color:#66cccc">
+				 <p>Layer 1</p>
+			 </div>
+			 <div style="background-color:#ffc000">
+				 <p>Layer 2</p>
+			 </div>
+		 </div>
+	 </div>
+
 	 Circular :
 	 <div id="mflick2" class="flick">
 		 <div style="background-color:#CC66CC">

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -82,9 +82,14 @@ QUnit.test("Check for the initialization", function(assert) {
 	var inst1 = this.create("#mflick1");
 	var inst2 = this.create("#mflick2", { horizontal: false });
 
+	// https://github.com/naver/egjs/issues/216
+	var $container = $("#mflick1-1 > :first-child").attr("id", "container");
+	var inst3 = this.create("#mflick1-1");
+
 	// Then
 	assert.deepEqual(inst1.$container.width(), inst1.$container.parent().width(), "Then panel container was added and the width is same as wrapper element.");
-	assert.deepEqual(inst2.$container.height(), inst1.$container.parent().height(), "Then panel container was added and the height is same as wrapper element.");
+	assert.deepEqual(inst2.$container.height(), inst2.$container.parent().height(), "Then panel container was added and the height is same as wrapper element.");
+	assert.deepEqual(inst3.$container.width(), inst3.$container.parent().width(), "Then panel container was added and the width is same as wrapper element.");
 
 	// Given
 	inst1._conf.panel.$list.css("padding", "0 20px");
@@ -93,6 +98,8 @@ QUnit.test("Check for the initialization", function(assert) {
 	// Then
 	assert.equal(inst1._conf.panel.size, inst1._conf.panel.$list.outerWidth(), "The panel should maintain same width as wrapper element.");
 	assert.equal(inst2._conf.panel.size, inst2._conf.panel.$list.outerHeight(), "The panel should maintain same height as wrapper element.");
+
+	assert.equal($container.attr("id"), inst3.$container.attr("id"), "The given DOM is used as container element?");
 });
 
 QUnit.module("Setting options", hooks);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#216

## Details
<!-- Detailed description of the change/feature -->
When container-ish element exist, wrapping panel elements, then use given element
instead of wrapping with new one.

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 