### PR TITLE
chore(dev-env): Upgrade nodejs version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10.40"
+  - "4"
 before_install:
   - npm install -g grunt-cli
   - npm install -g bower


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#363

## Details
<!-- Detailed description of the change/feature -->
0.10.40 to 4 (latest 4.x release)

Agreed to upgrade to 4.5, but Travis doesn't have that version.
- https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Available-Versions

Just declaring major version "4" will run `4 latest 4.x release`.

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@naver/egjs-dev