### PR TITLE
fix(flicking): Corrected direction param on .moveTo()

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -1337,24 +1337,20 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				return this;
 			}
 
-			if (circular) {
-				indexToMove = no - panel.no;
+			indexToMove = no - (circular ? panel.no : currentIndex);
+			isPositive = indexToMove > 0;
+
+			// check for real panel count which can be moved on each sides in circular mode
+			if (circular &&
+				Math.abs(indexToMove) >
+					(isPositive ? panel.count - (currentIndex + 1) : currentIndex)) {
+				indexToMove = indexToMove + (isPositive ? -1 : 1) * panel.count;
 				isPositive = indexToMove > 0;
-
-				// check for real panel count which can be moved on each sides
-				if (Math.abs(indexToMove) > (isPositive ?
-					panel.count - (currentIndex + 1) : currentIndex)) {
-					indexToMove = indexToMove + (isPositive ? -1 : 1) * panel.count;
-				}
-
-				this._setPanelNo({ no: no });
-			} else {
-				indexToMove = no - currentIndex;
-				this._setPanelNo({ index: no, no: no });
 			}
 
+			this._setPanelNo(circular ? { no: no } : { no: no, index: no });
 			this._conf.indexToMove = indexToMove;
-			this._setValueToMove(indexToMove > 0);
+			this._setValueToMove(isPositive);
 
 			this._movePanelByPhase(
 				circular ? "setBy" : "setTo",

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -1354,7 +1354,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			}
 
 			this._conf.indexToMove = indexToMove;
-			this._setValueToMove(isPositive);
+			this._setValueToMove(indexToMove > 0);
 
 			this._movePanelByPhase(
 				circular ? "setBy" : "setTo",

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -945,6 +945,48 @@ QUnit.test("Check for functionality", function(assert) {
 	runTest(1,value);
 });
 
+QUnit.test("Check for the direction", function(assert) {
+	var el;
+	var inst;
+	var MC = eg.MovableCoord;
+
+	var setCondition = function(no) {
+		el = inst.$wrapper[0];
+
+		el.eventDirection = [];
+		inst.moveTo(no, 0);
+	};
+
+	var runTest = function(direction) {
+		var eventDirection = $.unique(el.eventDirection);
+		var strDirection = direction === MC.DIRECTION_LEFT ? "LEFT" : "RIGHT";
+
+		assert.equal(direction, eventDirection.length === 1 && eventDirection[0], "Panel moved to "+ strDirection +"?");
+	};
+
+	// non-circular
+	inst = this.create("#mflick1");
+	setCondition(1);
+	runTest(MC.DIRECTION_LEFT);
+
+	setCondition(0);
+	runTest(MC.DIRECTION_RIGHT);
+
+	// circular
+	inst = this.create("#mflick2", {
+		circular : true
+	});
+
+	setCondition(2);
+	runTest(MC.DIRECTION_RIGHT);
+
+	setCondition(0);
+	runTest(MC.DIRECTION_LEFT);
+
+	setCondition(1);
+	runTest(MC.DIRECTION_LEFT);
+});
+
 QUnit.test("Animation #1 - Default duration value", function(assert) {
 	var done = assert.async();
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#436

## Details
<!-- Detailed description of the change/feature -->
Fixed param value on evaluating direction.
(#436 issue happens because of wrong direction value on calling `.moveTo()`)

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 