### PR TITLE
fix(agent): invalid browser version of iOS WebView

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -233,6 +233,19 @@ eg.module("agent", [eg], function(ns) {
 		return ret;
 	}
 
+	/**
+	 * agent post processing
+	 */
+	function postProcess(agent) {
+		agent.browser.name = agent.browser.name.toLowerCase();
+		agent.os.name = agent.os.name.toLowerCase();
+
+		if (agent.os.name === "ios" && agent.browser.webview) {
+			agent.browser.version = "-1";
+		}
+		return agent;
+	}
+
 	ns.Agent = {
 		"create": function(useragent) {
 			this.ua = UA = useragent;
@@ -246,10 +259,7 @@ eg.module("agent", [eg], function(ns) {
 			agent.os.version = getOSVersion(agent.os.name);
 			agent.browser.webview = isWebview();
 
-			agent.browser.name = agent.browser.name.toLowerCase();
-			agent.os.name = agent.os.name.toLowerCase();
-
-			return agent;
+			return postProcess(agent);
 		}
 	};
 });

--- a/test/unit/js/agent_info.js
+++ b/test/unit/js/agent_info.js
@@ -232,6 +232,40 @@ var ua = [
         "isTransitional" : false,
         "_hasClickBug" : true
     },
+		{
+        // iPhone 10.0 - WKWebView
+        "device" : "iPhone 10.0 - WKWebView",
+        "ua" : "Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Mobile/14A456 NAVER(inapp; search; 560; 7.7.0; 7)",
+        "os" : {
+            "name" : "ios",
+            "version" : "10.0.2"
+        },
+        "browser" : {
+            "name" : "safari",
+            "version" : "-1",
+            "webview" : true
+        },
+        "isHWAccelerable" : true,
+        "isTransitional" : false,
+        "_hasClickBug" : true
+    },
+		{
+        // iPad 10.0 - WKWebView
+        "device" : "iPad 10.0 - WKWebView",
+        "ua" : "Mozilla/5.0 (iPad; CPU OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Mobile/14A456 Version/5.1 Safari/7534.48.3 NAVER(inapp; search; 134; 7.7.0)",
+        "os" : {
+            "name" : "ios",
+            "version" : "10.0.2"
+        },
+        "browser" : {
+            "name" : "safari",
+            "version" : "-1",
+            "webview" : true
+        },
+        "isHWAccelerable" : true,
+        "isTransitional" : false,
+        "_hasClickBug" : true
+    },
 	{
 		// GalaxyS:2.1
 		"device" : "GalaxyS:2.1",


### PR DESCRIPTION
Makes iOS WebView returns `-1` as a browser version. Because iOS WebView version's consistency

## Issue
#440 

## Details
eg.agent returns invalid borwser version from webview on iPad (iOS 10.0.2)

## Preferred reviewers
@happyhj @sculove 