### PR TITLE
fix(flicking): Fix getting target panel for adaptiveHeight

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -791,10 +791,21 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			var height;
 			var dataName = "data-height";
 
-			$panel = this[ "get" + (
+			var conf = this._conf;
+			var indexToMove = conf.indexToMove;
+
+			$panel = indexToMove === 0 ?
+
+				// panel moved by 1
+				this[ "get" + (
 					direction === MC.DIRECTION_LEFT && "Next" ||
 					direction === MC.DIRECTION_RIGHT && "Prev" || ""
-				) + "Element" ]();
+				) + "Element" ]() :
+
+				// panel moved by .moveTo()
+				conf.panel.$list.eq(
+					conf.panel.currIndex + indexToMove
+				);
 
 			$first = $panel.find(":first");
 			height = $first.attr(dataName);

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -458,17 +458,22 @@ QUnit.test("hwAccelerable", function(assert) {
 QUnit.test("adaptiveHeight", function(assert) {
 	// Given
 	var inst = this.create("#mflick4", {
-		adaptiveHeight: true,
-		circular: true
+		adaptiveHeight: true
 	});
 
 	// Then
-	for (var i = 0; i < inst._conf.panel.count; i++) {
+	for (var i = 0; i < inst._conf.panel.count-1; i++) {
 		var panelHeight = inst.getElement().outerHeight(true);
 		assert.ok(panelHeight === inst.$container.height(), "Should update container's height according to each panel's height");
 		inst.next(0);
 		assert.ok(panelHeight === Number(inst.getPrevElement().children(':first').attr('data-height')), "Should cache each panel's height to first element");
 	}
+
+	// When
+	inst.moveTo(0,0);
+
+	// Then
+	assert.ok(inst.$container.height() === Number(inst.getElement().children(':first').attr('data-height')), "The container's height should be updated");
 });
 
 QUnit.test("thresholdAngle", function(assert) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#445 

## Details
<!-- Detailed description of the change/feature -->
When adpativeHeight option is set and moved by .moveTo(),
correct getting target panel element

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 