### PR TITLE
fix(flicking): Fix wrong referencing of panel elements

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -169,10 +169,11 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		_setConfig: function($children, _prefix) {
 			var options = this.options;
 			var padding = options.previewPadding;
+			var $first = $children.eq(0);
 
-			if ($children.eq(0).hasClass(options.prefix + "-container")) {
-				this.$container = $children;
-				$children = $children.children();
+			if ($first.hasClass(options.prefix + "-container")) {
+				this.$container = $first;
+				$children = $first.children();
 			}
 
 			// config value

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -169,11 +169,11 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		_setConfig: function($children, _prefix) {
 			var options = this.options;
 			var padding = options.previewPadding;
-			var $first = $children.eq(0);
+			var $container = $children.filter("." + options.prefix + "-container:first");
 
-			if ($first.hasClass(options.prefix + "-container")) {
-				this.$container = $first;
-				$children = $first.children();
+			if ($container.length) {
+				this.$container = $container;
+				$children = $container.children();
 			}
 
 			// config value

--- a/test/unit/flicking.test.html
+++ b/test/unit/flicking.test.html
@@ -50,6 +50,11 @@
 				 <p>Layer 2</p>
 			 </div>
 		 </div>
+		 <div class="spot_cont_box">
+			 <div class="item_source"></div>
+			 <div class="item_source"></div>
+			 <div class="item_source"></div>
+		 </div>
 	 </div>
 
 	 Circular :

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -84,6 +84,7 @@ QUnit.test("Check for the initialization", function(assert) {
 
 	// https://github.com/naver/egjs/issues/216
 	var $container = $("#mflick1-1 > :first-child").attr("id", "container");
+	var panelCount = $container.children().size();
 	var inst3 = this.create("#mflick1-1");
 
 	// Then
@@ -100,6 +101,7 @@ QUnit.test("Check for the initialization", function(assert) {
 	assert.equal(inst2._conf.panel.size, inst2._conf.panel.$list.outerHeight(), "The panel should maintain same height as wrapper element.");
 
 	assert.equal($container.attr("id"), inst3.$container.attr("id"), "The given DOM is used as container element?");
+	assert.equal(panelCount, inst3._conf.panel.$list.length, "The panels are taken properly referenced?");
 });
 
 QUnit.module("Setting options", hooks);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#438

## Details
<!-- Detailed description of the change/feature -->
When container element is given,
corrected referencing panel elements properly.

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 