### PR TITLE
fix(infiniteGrid): fire append event after resize

### DIFF
--- a/src/infiniteGrid.js
+++ b/src/infiniteGrid.js
@@ -169,6 +169,7 @@ eg.module("infiniteGrid", ["jQuery", eg, window, document], function($, ns, glob
 				self._refreshViewport();
 				(self.$el.innerWidth() !== self._containerWidth) && self.layout(true);
 				self._resizeTimeout = null;
+				self._prevScrollTop = -1;
 			}, 100);
 		},
 		_refreshViewport: function() {

--- a/test/unit/js/infiniteGrid.test.js
+++ b/test/unit/js/infiniteGrid.test.js
@@ -874,7 +874,8 @@ QUnit.test("if width is not changed, layout should be not called on resize event
 	$global.on("resize", function(e) {
 		resizeCount++;
 	});
-
+	$global.scrollTop(10000);
+	
 	// When
 	$global.trigger("resize");
 
@@ -920,6 +921,22 @@ QUnit.test("check _refreshViewport method", function(assert) {
 	assert.equal(inst._clientHeight, 200, "height is changed");
 });
 
+
+QUnit.test("check _prevScrollTop after resize event.", function(assert) {
+	// Given
+	var done = assert.async();
+	var inst = this.inst = new eg.InfiniteGrid("#grid");
+	assert.equal(inst._prevScrollTop, 0);
+	
+	// When
+	inst._onResize();
+
+	// Then
+	setTimeout(function() {
+		assert.equal(inst._prevScrollTop, -1);
+		done();
+	},200);
+});
 
 QUnit.module("infiniteGrid layout(false) Test", {
 	beforeEach : function() {


### PR DESCRIPTION
## Issue
#450

## Details
- add code that reset _prevScrollPos  property after resizing 

## Preferred reviewers
@netil 