### PR TITLE
refactor: make code clean by removing unused/unnecessary codes

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -256,9 +256,9 @@ eg.module("component", [eg], function(ns) {
 			if (handlerList) {
 				var k;
 				var handlerFunction;
-				for (k = 0, handlerFunction; handlerFunction = handlerList[k]; k++) {
+				for (k = 0; handlerFunction = handlerList[k]; k++) {
 					if (handlerFunction === handlerToDetach) {
-						handlerList = handlerList.splice(k, 1);
+						handlerList.splice(k, 1);
 						break;
 					}
 				}

--- a/src/customEvent/scrollEnd.js
+++ b/src/customEvent/scrollEnd.js
@@ -85,7 +85,7 @@ eg.module("scrollEnd", ["jQuery", eg, window], function($, ns, global) {
 				retValue = SCROLLBASE;
 			} else if (deviceName === "Android") {
 				osVersion = userAgent.match(/Android\b(.*?);/);
-				if (!/Chrome/.test(userAgent) && osVersion && parseFloat(osVersion, 10) <= 2.3) {
+				if (!/Chrome/.test(userAgent) && osVersion && parseFloat(osVersion) <= 2.3) {
 					retValue = SCROLLBASE;
 				}
 			}

--- a/src/hook/pauseResume.js
+++ b/src/hook/pauseResume.js
@@ -196,7 +196,7 @@ eg.module("pauseResume", ["jQuery"], function($) {
 
 			//Clear fx-queue except 1 dummy function
 			//for promise not to be expired when calling stop()
-			$.queue(this, type || "fx", [$.noop]);
+			$.queue(this, type, [$.noop]);
 			stopFn.call($(this));
 
 			//Remember current animation property
@@ -255,7 +255,7 @@ eg.module("pauseResume", ["jQuery"], function($) {
 
 			//Clear fx-queue,
 			//And this queue will be initialized by animate call.
-			$.queue(this, type || "fx", []);
+			$.queue(this, type, []);
 
 			// Restore __aniProps
 			i = 0;

--- a/src/visible.js
+++ b/src/visible.js
@@ -102,10 +102,6 @@ eg.module("visible", ["jQuery", eg, document], function($, ns, doc) {
 				delay = -1;
 			}
 
-			if (typeof delay === "undefined") {
-				delay = -1;
-			}
-
 			if (typeof containment === "undefined") {
 				containment = false;
 			}

--- a/test/unit/js/agent.test.js
+++ b/test/unit/js/agent.test.js
@@ -33,18 +33,18 @@ $.each( nativeVersionProfile, function( i, v ) {
 		eg.invoke("eg",[null, null, this.fakeWindow]);
 		eg.hook = {};
 		eg.hook.agent = function(agent){
-			var dm = dm || v._documentMode || -1,
+			var dm = v._documentMode || -1,
 				nativeVersion;
 			if(dm > 0) {
 				if(m = /(Trident)[\/\s]([\d.]+)/.exec(v.ua)) {
 					if(m[2] > 3) {
-						nativeVersion = parseFloat(m[2],10) + 4;
+						nativeVersion = parseFloat(m[2]) + 4;
 					}
 				} else {
 					nativeVersion = dm;
 				}
 			} else {
-				nativeVersion = parseFloat(agent.browser.version,10);
+				nativeVersion = parseFloat(agent.browser.version);
 			}
 
 			agent.browser.nativeVersion = nativeVersion;

--- a/test/unit/js/class.test.js
+++ b/test/unit/js/class.test.js
@@ -83,7 +83,7 @@ test( "Class extend basic test", function(  ) {
   strictEqual(nSumOfB, 15, "A Class constructor initialized values successfully");
   strictEqual(nSumOfA, 6, "B Class constructor initialized values successfully");
   strictEqual(nMultiOfB, 120, "B Class has its own method.");
-  strictEqual(b.multi(), 6, "Changed properties of B instance successfully");
+  strictEqual(nChangedMultiB, 6, "Changed properties of B instance successfully");
   throws(
   	function() {
   		a.multi();

--- a/test/unit/js/component.test.js
+++ b/test/unit/js/component.test.js
@@ -227,7 +227,7 @@ test("Return value test for trigger method",function(){
 	//Given
 	this.oClass.on("test", noop);
 	//When
-	var returnVal = this.oClass.trigger("test");
+	returnVal = this.oClass.trigger("test");
 	//Then
 	ok(returnVal, "When pull the event handler trigger for 'test', return value must be true.");
 });
@@ -332,14 +332,14 @@ test("Option method should be support 4 features.",function(){
 
 	//Given
 	//When
-	var result = this.oClass.option("foo",2);
+	result = this.oClass.option("foo",2);
 	//Then
 	equal( this.oClass.option("foo"), 2);
 	ok( result instanceof TestClass );
 
 	//Given
 	//When
-	var result = this.oClass.option({
+	result = this.oClass.option({
 		"foo": 3,
 		"bar": 4
 	});
@@ -350,7 +350,7 @@ test("Option method should be support 4 features.",function(){
 
 	//Given
 	//When
-	var result = this.oClass.option();
+	result = this.oClass.option();
 	//Then
 	deepEqual( result, {
 		"foo": 3,

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -1400,7 +1400,7 @@ QUnit.test("When changes panel normally", function(assert) {
 
 				$.each(panel, function(i) {
 					var oPanel = panel[i];
-					var condition, value;
+					var condition;
 
 					if (i === "flickEnd") {
 						condition = {
@@ -1415,10 +1415,12 @@ QUnit.test("When changes panel normally", function(assert) {
 						};
 
 						$.each(oPanel, function(x) {
-							if (/^(index|no|getIndex)$/.test(x)) {
-								var value = currentPanel[x];
+							var value;
 
-								if (!isCircular || (isCircular && x !== "index")) {
+							if (/^(index|no|getIndex)$/.test(x)) {
+								value = currentPanel[x];
+
+								if (!isCircular || (x !== "index")) {
 									value += 1;
 								}
 

--- a/test/unit/js/infiniteGrid.test.js
+++ b/test/unit/js/infiniteGrid.test.js
@@ -372,7 +372,7 @@ QUnit.test("check item/element order and check removed parts", function(assert) 
 			// Then
 			assert.equal(e.target.length, this.options.count, "check remove a count of items");
 			assert.equal(e.croppedCount, 20, "check croppedCount");
-			var self = this;
+
 			this.$el.children().slice(0,e.target.length).each( function(i, v) {
 				assert.equal($(v).data("prepend-index"), i, "check element order " + i);
 			});

--- a/test/unit/js/persist.test.js
+++ b/test/unit/js/persist.test.js
@@ -116,6 +116,9 @@ var UniversalTestMap = {
 		"testFunc": function(v){
 			// Given
 			var state = $.persist("TESTKEY");
+
+			equal(state, null);
+
 			$.persist("TESTKEY", this.data);
 
 			// When

--- a/test/unit/js/rotate.test.js
+++ b/test/unit/js/rotate.test.js
@@ -336,7 +336,7 @@ test("If event is orientationchange then trigger and android.", function() {
 
 	// When
 	this.clock.tick(510);
-	var checkFail = method.handler({
+	checkFail = method.handler({
 		type: "orientationchange"
 	});
 	this.clock.tick(310);
@@ -406,6 +406,7 @@ test("If eg.isPortrait() affect the rotate event not to be fired.", function() {
 	var isCall = false;
 	var isVertical1 = false;
 	var isVertical2 = false;
+	// Note: Please check this 'agent' variable is actually used.
 	var agent = eg.agent();
 	agent = {
 		os: "android",

--- a/test/unit/js/visible.test.js
+++ b/test/unit/js/visible.test.js
@@ -49,8 +49,7 @@ test("check a visible/invisible status", function(assert) {
 test("When a scroll position of the window was changed", function(assert) {
 	// Given
 	var done = assert.async();
-	var i, el,
-		invisible = [],
+	var invisible = [],
 		visible = [];
 
 	// When


### PR DESCRIPTION
* refactor(component): remove unused variable and return value
 - Array#splice() changes itself and returns deleted elements. So
   assigning return value is not necessary in this case.
* refactor(visible): remove unexecuted codes by above condition
* refactor(scrollEnd): remove unnecessary radix parameter for parseFloat()
 - parseFloat() has only one argument unlike parseInt
* refactor(pauseResume): remove unnecessary condition check
 - type is set to constant "fx" above
* test(agent): remove uninitialized variable use and fix parseFloat()
* test(class): use previously calculated variable 'nChangedMultiB'
* test(component): remove redundant 'var' because it is function scoped
* test(flicking): move 'var' declaration under its function
* test(infiniteGrid): remove unused variable 'self'
* test(persist): add initialization check for test set-up
* test(rotate): remove redundant 'var'
* test(visible): remove unused variables

And I think 'agent' variable in test(rotate) is not necessary, so I added
a note for it.

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
