### PR TITLE
fix(flicking): Improve .resize() on adaptiveHeight option

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -83,6 +83,9 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 	var IS_ANDROID2 = ns.agent().os;
 	IS_ANDROID2 = IS_ANDROID2.name === "android" && /^2\./.test(IS_ANDROID2.version);
 
+	// data-height attribute's name for adaptiveHeight option
+	var DATA_HEIGHT = "data-height";
+
 	ns.Flicking = ns.Class.extend(ns.Component, {
 		_events: function() {
 			return EVENTS;
@@ -189,8 +192,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 					origCount: 0,		// total count of given original panels
 					changed: false,		// if panel changed
 					animating: false,	// current animating status boolean
-					minCount: padding[0] + padding[1] > 0 ? 5 : 3,  // minimum panel count
-					dataHeight: "data-height"   // data-height attribute's name for adaptiveHeight option
+					minCount: padding[0] + padding[1] > 0 ? 5 : 3  // minimum panel count
 				},
 				touch: {
 					holdPos: [0, 0],	// hold x,y coordinate
@@ -788,8 +790,6 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			var $first;
 			var $children;
 			var height;
-			var dataName = "data-height";
-
 			var conf = this._conf;
 			var indexToMove = conf.indexToMove;
 
@@ -807,14 +807,14 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				);
 
 			$first = $panel.find(":first");
-			height = $first.attr(dataName);
+			height = $first.attr(DATA_HEIGHT);
 
 			if (!height) {
 				$children = $panel.children();
 				height = ($children.length > 1 ? $panel.css("height", "auto") : $first)
 					.outerHeight(true);
 
-				$first.attr(dataName, height);
+				$first.attr(DATA_HEIGHT, height);
 			}
 
 			this.$wrapper.height(height);
@@ -1437,9 +1437,9 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 
 			// remove data-height attribute and re-evaluate panel's height
 			if (options.adaptiveHeight) {
-				var $panel = this.$container.find("[" + panel.dataHeight + "]");
+				var $panel = this.$container.find("[" + DATA_HEIGHT + "]");
 
-				$panel.size() && $panel.attr(panel.dataHeight, null) &&
+				$panel.size() && $panel.attr(DATA_HEIGHT, null) &&
 					this._setAdaptiveHeight();
 			}
 

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -189,7 +189,8 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 					origCount: 0,		// total count of given original panels
 					changed: false,		// if panel changed
 					animating: false,	// current animating status boolean
-					minCount: padding[0] + padding[1] > 0 ? 5 : 3  // minimum panel count
+					minCount: padding[0] + padding[1] > 0 ? 5 : 3,  // minimum panel count
+					dataHeight: "data-height"   // data-height attribute's name for adaptiveHeight option
 				},
 				touch: {
 					holdPos: [0, 0],	// hold x,y coordinate
@@ -1433,6 +1434,14 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			// resize elements
 			horizontal && this.$container.width(maxCoords[0] + panelSize);
 			panel.$list.css(horizontal ? "width" : "height", panelSize);
+
+			// remove data-height attribute and re-evaluate panel's height
+			if (options.adaptiveHeight) {
+				var $panel = this.$container.find("[" + panel.dataHeight + "]");
+
+				$panel.size() && $panel.attr(panel.dataHeight, null) &&
+					this._setAdaptiveHeight();
+			}
 
 			this._mcInst.options.max = maxCoords;
 			this._setMovableCoord("setTo", [panelSize * panel.index, 0], true, 0);

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -463,19 +463,36 @@ QUnit.test("adaptiveHeight", function(assert) {
 		adaptiveHeight: true
 	});
 
-	// Then
-	for (var i = 0; i < inst._conf.panel.count-1; i++) {
-		var panelHeight = inst.getElement().outerHeight(true);
-		assert.ok(panelHeight === inst.$container.height(), "Should update container's height according to each panel's height");
-		inst.next(0);
-		assert.ok(panelHeight === Number(inst.getPrevElement().children(':first').attr('data-height')), "Should cache each panel's height to first element");
-	}
+	var runTest = function() {
+		for (var i = 0; i < inst._conf.panel.count - 1; i++) {
+			var panelHeight = inst.getElement().outerHeight(true);
+			assert.ok(panelHeight === inst.$container.height(), "Should update container's height according to each panel's height");
 
-	// When
-	inst.moveTo(0,0);
+			// When
+			inst.next(0);
+
+			// Then
+			assert.ok(panelHeight === Number(inst.getPrevElement().children(':first').attr('data-height')), "Should cache each panel's height to first element");
+		}
+
+		// When
+		inst.moveTo(0, 0);
+
+		// Then
+		assert.ok(inst.$container.height() === Number(inst.getElement().children(':first').attr('data-height')), "The container's height should be updated");
+	};
 
 	// Then
-	assert.ok(inst.$container.height() === Number(inst.getElement().children(':first').attr('data-height')), "The container's height should be updated");
+	runTest();
+
+	// When - simulate rotate case
+	inst.$wrapper.attr("style", "font-size:52px");
+
+	// Then
+	inst.resize();
+	runTest();
+
+	inst.$wrapper.attr("style", null);
 });
 
 QUnit.test("thresholdAngle", function(assert) {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#478

## Details
<!-- Detailed description of the change/feature -->
In case of rotate(or in case of panel's height changes), need to re-evaluate panel's height value.
This fixes removing 'data-height' attribute and re-evaluate calling ._setAdaptiveHeight().

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 