### PR TITLE
fix(flicking): Fix on previewPadding resizing

### DIFF
--- a/src/flicking.js
+++ b/src/flicking.js
@@ -1067,8 +1067,8 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 				currPos = this._getDataByDirection(mcInst.get())[0];
 
 				// if current position out of range
-				if (( panel.currNo === 0 && touchDirection === conf.dirData[1] ||  // first panel
-					  panel.count - 1 === panel.currNo && touchDirection === conf.dirData[0]  // last panel
+				if ((panel.currNo === 0 && touchDirection === conf.dirData[1] ||  // first panel
+						panel.count - 1 === panel.currNo && touchDirection === conf.dirData[0]  // last panel
 					) && (currPos < 0 || currPos > max)) {
 					return false;
 				}

--- a/src/flicking.js
+++ b/src/flicking.js
@@ -1378,32 +1378,6 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 		},
 
 		/**
-		 * Update panel's previewPadding size according options.previewPadding
-		 */
-		_checkPadding: function () {
-			var options = this.options;
-			var previewPadding = options.previewPadding.concat();
-			var padding = this.$wrapper.css("padding").split(" ");
-
-			options.horizontal && padding.reverse();
-
-			// get current padding value
-			padding = padding.length === 2 ?
-				[ padding[0], padding[0] ] : [ padding[0], padding[2] ];
-
-			padding = $.map(padding, function(num) {
-				return parseInt(num, 10);
-			});
-
-			// update padding when current and given are different
-			if (previewPadding.length === 2 &&
-				previewPadding[0] !== padding[0] || previewPadding[1] !== padding[1]) {
-
-				this._setPadding(previewPadding);
-			}
-		},
-
-		/**
 		 * Updates the size of the panel.
 		 * @ko 패널의 크기를 갱신한다
 		 * @method eg.Flicking#resize
@@ -1429,7 +1403,7 @@ eg.module("flicking", ["jQuery", eg, window, document, eg.MovableCoord], functio
 			var maxCoords;
 
 			if (~~options.previewPadding.join("")) {
-				this._checkPadding();
+				this._setPadding(options.previewPadding.concat());
 				panelSize = panel.size;
 			} else if (horizontal) {
 				panelSize = panel.size = this.$wrapper.width();

--- a/test/unit/js/flicking.test.js
+++ b/test/unit/js/flicking.test.js
@@ -1188,6 +1188,12 @@ QUnit.test("When change padding option", function(assert) {
 
 	// Then
 	runTest([20,30], true);
+
+	// When
+	setCondition([0,20]);
+
+	// Then
+	runTest([0,20], true);
 	inst.destroy();
 
 	// Given


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#489 

## Details
<!-- Detailed description of the change/feature -->
Removed '_checkPadding()'. It doesn't necessarily need to check the difference and applying padding of panels, because call of resize is up to the decision of user.

## Preferred reviewers
<!-- Mention user/group to be reviewed by:
      anyone from maintainers(@naver/egjs-dev) or specific user (@USER1, @USER2) -->
@sculove 